### PR TITLE
Added JeOS Leap15 keg image definition

### DIFF
--- a/data/base/jeos/leap15/bootstrap.yaml
+++ b/data/base/jeos/leap15/bootstrap.yaml
@@ -1,0 +1,10 @@
+packages:
+  bootstrap:
+    jeos:
+      - openSUSE-release
+      - ca-certificates-mozilla
+      - ca-certificates
+      - cracklib-dict-full
+      - glibc-locale
+      - filesystem
+      - udev

--- a/data/base/jeos/leap15/config.yaml
+++ b/data/base/jeos/leap15/config.yaml
@@ -1,0 +1,67 @@
+config:
+  files:
+    JeOS-sysconfig:
+      - path: /etc/profile
+        append: True
+        content: |-
+          # yast in Public Cloud images fix
+          NCURSES_NO_UTF8_ACS=1
+          export NCURSES_NO_UTF8_ACS
+      - path: /etc/sysconfig/clock
+        append: True
+        content: |-
+          DEFAULT_TIMEZONE="Etc/UTC"
+          HWCLOCK="-u"
+          UTC="true"
+      - path: /etc/sysconfig/console
+        append: True
+        content: |-
+          CONSOLE_ENCODING="UTF-8"
+          CONSOLE_FONT="lat9w-16.psfu"
+          CONSOLE_SCREENMAP="trivial"
+  scripts:
+    JeOS-config:
+      - allow-root-console
+      - polkit-set-default-privs
+      - remove-root-pw
+      - set-prodlink
+      - zypp-disable-delta-rpms
+  services:
+    JeOS-services:
+      - boot.device-mapper
+      - haveged
+      - sshd
+      - name: acpid
+        enable: False
+      - name: boot.efivars
+        enable: False
+      - name: boot.lvm
+        enable: False
+      - name: boot.md
+        enable: False
+      - name: boot.multipath
+        enable: False
+      - name: display-manager
+        enable: False
+      - name: kbd
+        enable: False
+  sysconfig:
+    JeOS-sysconfig:
+      - file: /etc/sysconfig/keyboard
+        name: COMPOSETABLE
+        value: "clear latin1.add"
+      - file: /etc/sysconfig/language
+        name: INSTALLED_LANGUAGES
+        value: ""
+      - file: /etc/sysconfig/language
+        name: RC_LANG
+        value: "C.UTF-8"
+      - file: /etc/sysconfig/security
+        name: POLKIT_DEFAULT_PRIVS
+        value: "restrictive"
+      - file: /etc/sysconfig/windowmanager
+        name: DEFAULT_WM
+        value: ""
+      - file: /etc/sysconfig/windowmanager
+        name: INSTALL_DESKTOP_EXTENSIONS
+        value: "no"

--- a/data/base/jeos/leap15/packages.yaml
+++ b/data/base/jeos/leap15/packages.yaml
@@ -1,0 +1,16 @@
+packages:
+  image:
+    jeos:
+      - patterns-openSUSE-base
+      - vim
+      - shim
+      - which
+      - openssh
+      - iproute2
+      - tar
+      - kernel-default
+      - timezone
+      - grub2
+      - name: grub2-i386-pc
+      - name: grub2-x86_64-efi
+        arch: x86_64

--- a/images/leap/jeos/15.2/image.yaml
+++ b/images/leap/jeos/15.2/image.yaml
@@ -1,0 +1,9 @@
+include-paths:
+  - base/jeos/leap15
+image:
+  name: Leap15.2-JeOS
+  specification: "Leap 15.2 guest image"
+  version: 1.15.2
+repositories:
+  -
+    path: obs://openSUSE:Leap:15.2/standard

--- a/images/leap/jeos/profiles.yaml
+++ b/images/leap/jeos/profiles.yaml
@@ -1,0 +1,5 @@
+profiles:
+  default:
+    description: Default Profile
+    include:
+      - csp


### PR DESCRIPTION
For demo and documentation purposes as well as to provide users
an easy start with Keg, I have added a Leap15 based image definition
which can also be build outside of obs and without access to SLES
repos