### PR TITLE
Update scripts section to be more explicit

### DIFF
--- a/data/base/jeos/leap15/config.yaml
+++ b/data/base/jeos/leap15/config.yaml
@@ -1,67 +1,67 @@
 config:
-  files:
-    JeOS-sysconfig:
-      - path: /etc/profile
-        append: True
-        content: |-
-          # yast in Public Cloud images fix
-          NCURSES_NO_UTF8_ACS=1
-          export NCURSES_NO_UTF8_ACS
-      - path: /etc/sysconfig/clock
-        append: True
-        content: |-
-          DEFAULT_TIMEZONE="Etc/UTC"
-          HWCLOCK="-u"
-          UTC="true"
-      - path: /etc/sysconfig/console
-        append: True
-        content: |-
-          CONSOLE_ENCODING="UTF-8"
-          CONSOLE_FONT="lat9w-16.psfu"
-          CONSOLE_SCREENMAP="trivial"
-  scripts:
+  config_script:
     JeOS-config:
       - allow-root-console
       - polkit-set-default-privs
       - remove-root-pw
       - set-prodlink
       - zypp-disable-delta-rpms
-  services:
-    JeOS-services:
-      - boot.device-mapper
-      - haveged
-      - sshd
-      - name: acpid
-        enable: False
-      - name: boot.efivars
-        enable: False
-      - name: boot.lvm
-        enable: False
-      - name: boot.md
-        enable: False
-      - name: boot.multipath
-        enable: False
-      - name: display-manager
-        enable: False
-      - name: kbd
-        enable: False
-  sysconfig:
-    JeOS-sysconfig:
-      - file: /etc/sysconfig/keyboard
-        name: COMPOSETABLE
-        value: "clear latin1.add"
-      - file: /etc/sysconfig/language
-        name: INSTALLED_LANGUAGES
-        value: ""
-      - file: /etc/sysconfig/language
-        name: RC_LANG
-        value: "C.UTF-8"
-      - file: /etc/sysconfig/security
-        name: POLKIT_DEFAULT_PRIVS
-        value: "restrictive"
-      - file: /etc/sysconfig/windowmanager
-        name: DEFAULT_WM
-        value: ""
-      - file: /etc/sysconfig/windowmanager
-        name: INSTALL_DESKTOP_EXTENSIONS
-        value: "no"
+    files:
+      JeOS-sysconfig:
+        - path: /etc/profile
+          append: True
+          content: |-
+            # yast in Public Cloud images fix
+            NCURSES_NO_UTF8_ACS=1
+            export NCURSES_NO_UTF8_ACS
+        - path: /etc/sysconfig/clock
+          append: True
+          content: |-
+            DEFAULT_TIMEZONE="Etc/UTC"
+            HWCLOCK="-u"
+            UTC="true"
+        - path: /etc/sysconfig/console
+          append: True
+          content: |-
+            CONSOLE_ENCODING="UTF-8"
+            CONSOLE_FONT="lat9w-16.psfu"
+            CONSOLE_SCREENMAP="trivial"
+    services:
+      JeOS-services:
+        - boot.device-mapper
+        - haveged
+        - sshd
+        - name: acpid
+          enable: False
+        - name: boot.efivars
+          enable: False
+        - name: boot.lvm
+          enable: False
+        - name: boot.md
+          enable: False
+        - name: boot.multipath
+          enable: False
+        - name: display-manager
+          enable: False
+        - name: kbd
+          enable: False
+    sysconfig:
+      JeOS-sysconfig:
+        - file: /etc/sysconfig/keyboard
+          name: COMPOSETABLE
+          value: "clear latin1.add"
+        - file: /etc/sysconfig/language
+          name: INSTALLED_LANGUAGES
+          value: ""
+        - file: /etc/sysconfig/language
+          name: RC_LANG
+          value: "C.UTF-8"
+        - file: /etc/sysconfig/security
+          name: POLKIT_DEFAULT_PRIVS
+          value: "restrictive"
+        - file: /etc/sysconfig/windowmanager
+          name: DEFAULT_WM
+          value: ""
+        - file: /etc/sysconfig/windowmanager
+          name: INSTALL_DESKTOP_EXTENSIONS
+          value: "no"

--- a/data/base/jeos/sle15/config.yaml
+++ b/data/base/jeos/sle15/config.yaml
@@ -1,67 +1,67 @@
 config:
-  files:
-    JeOS-sysconfig:
-      - path: /etc/profile
-        append: True
-        content: |-
-          # yast in Public Cloud images fix
-          NCURSES_NO_UTF8_ACS=1
-          export NCURSES_NO_UTF8_ACS
-      - path: /etc/sysconfig/clock
-        append: True
-        content: |-
-          DEFAULT_TIMEZONE="Etc/UTC"
-          HWCLOCK="-u"
-          UTC="true"
-      - path: /etc/sysconfig/console
-        append: True
-        content: |-
-          CONSOLE_ENCODING="UTF-8"
-          CONSOLE_FONT="lat9w-16.psfu"
-          CONSOLE_SCREENMAP="trivial"
-  scripts:
+  config_script:
     JeOS-config:
       - allow-root-console
       - polkit-set-default-privs
       - remove-root-pw
       - set-prodlink
       - zypp-disable-delta-rpms
-  services:
-    JeOS-services:
-      - boot.device-mapper
-      - haveged
-      - sshd
-      - name: acpid
-        enable: False
-      - name: boot.efivars
-        enable: False
-      - name: boot.lvm
-        enable: False
-      - name: boot.md
-        enable: False
-      - name: boot.multipath
-        enable: False
-      - name: display-manager
-        enable: False
-      - name: kbd
-        enable: False
-  sysconfig:
-    JeOS-sysconfig:
-      - file: /etc/sysconfig/keyboard
-        name: COMPOSETABLE
-        value: "clear latin1.add"
-      - file: /etc/sysconfig/language
-        name: INSTALLED_LANGUAGES
-        value: ""
-      - file: /etc/sysconfig/language
-        name: RC_LANG
-        value: "C.UTF-8"
-      - file: /etc/sysconfig/security
-        name: POLKIT_DEFAULT_PRIVS
-        value: "restrictive"
-      - file: /etc/sysconfig/windowmanager
-        name: DEFAULT_WM
-        value: ""
-      - file: /etc/sysconfig/windowmanager
-        name: INSTALL_DESKTOP_EXTENSIONS
-        value: "no"
+    files:
+      JeOS-sysconfig:
+        - path: /etc/profile
+          append: True
+          content: |-
+            # yast in Public Cloud images fix
+            NCURSES_NO_UTF8_ACS=1
+            export NCURSES_NO_UTF8_ACS
+        - path: /etc/sysconfig/clock
+          append: True
+          content: |-
+            DEFAULT_TIMEZONE="Etc/UTC"
+            HWCLOCK="-u"
+            UTC="true"
+        - path: /etc/sysconfig/console
+          append: True
+          content: |-
+            CONSOLE_ENCODING="UTF-8"
+            CONSOLE_FONT="lat9w-16.psfu"
+            CONSOLE_SCREENMAP="trivial"
+    services:
+      JeOS-services:
+        - boot.device-mapper
+        - haveged
+        - sshd
+        - name: acpid
+          enable: False
+        - name: boot.efivars
+          enable: False
+        - name: boot.lvm
+          enable: False
+        - name: boot.md
+          enable: False
+        - name: boot.multipath
+          enable: False
+        - name: display-manager
+          enable: False
+        - name: kbd
+          enable: False
+    sysconfig:
+      JeOS-sysconfig:
+        - file: /etc/sysconfig/keyboard
+          name: COMPOSETABLE
+          value: "clear latin1.add"
+        - file: /etc/sysconfig/language
+          name: INSTALLED_LANGUAGES
+          value: ""
+        - file: /etc/sysconfig/language
+          name: RC_LANG
+          value: "C.UTF-8"
+        - file: /etc/sysconfig/security
+          name: POLKIT_DEFAULT_PRIVS
+          value: "restrictive"
+        - file: /etc/sysconfig/windowmanager
+          name: DEFAULT_WM
+          value: ""
+        - file: /etc/sysconfig/windowmanager
+          name: INSTALL_DESKTOP_EXTENSIONS
+          value: "no"

--- a/data/csp/azure/sle15/config.yaml
+++ b/data/csp/azure/sle15/config.yaml
@@ -1,25 +1,25 @@
 config:
-  sysconfig:
-    Azure-config:
-      - file: /etc/sysconfig/network/config
-        name: NETCONFIG_MODULES_ORDER
-        value: "cloud-netconfig dns-resolver dns-bind dns-dnsmasq nis ntp-runtime"
-      - file: /etc/sysconfig/network/dhcp
-        name: DHCLIENT_SET_HOSTNAME
-        value: "no"
-  services:
-    Azure-config:
-      - chronyd
-      - cloud-config
-      - cloud-final
-      - cloud-init
-      - cloud-init-local
-      - cloud-netconfig.timer
-      - waagent
-  scripts:
+  config_script:
     Azure-config:
       - ssh-enable-keep-alive
       - waagent-disable-auto-update
       - waagent-enable-all-ssh-host-key-types
       - set-password-policy
       - keep-default-kernel-log-level
+    sysconfig:
+      Azure-config:
+        - file: /etc/sysconfig/network/config
+          name: NETCONFIG_MODULES_ORDER
+          value: "cloud-netconfig dns-resolver dns-bind dns-dnsmasq nis ntp-runtime"
+        - file: /etc/sysconfig/network/dhcp
+          name: DHCLIENT_SET_HOSTNAME
+          value: "no"
+    services:
+      Azure-config:
+        - chronyd
+        - cloud-config
+        - cloud-final
+        - cloud-init
+        - cloud-init-local
+        - cloud-netconfig.timer
+        - waagent

--- a/data/csp/ec2/sle15/config.yaml
+++ b/data/csp/ec2/sle15/config.yaml
@@ -1,21 +1,21 @@
 config:
-  sysconfig:
-    EC2-sysconfig:
-      - file: /etc/sysconfig/network/config
-        name: NETCONFIG_MODULES_ORDER
-        value: "cloud-netconfig dns-resolver dns-bind dns-dnsmasq nis ntp-runtime"
-      - file: /etc/sysconfig/network/dhcp
-        name: DHCLIENT_SET_HOSTNAME
-        value: "no"
-  services:
-    EC2-services:
-      - chronyd
-      - cloud-config
-      - cloud-final
-      - cloud-init
-      - cloud-init-local
-      - cloud-netconfig.timer
-  scripts:
+  config_script:
     EC2-config:
       - remove-aws-type-switch-conf
       - ssh-disable-password-login
+    sysconfig:
+      EC2-sysconfig:
+        - file: /etc/sysconfig/network/config
+          name: NETCONFIG_MODULES_ORDER
+          value: "cloud-netconfig dns-resolver dns-bind dns-dnsmasq nis ntp-runtime"
+        - file: /etc/sysconfig/network/dhcp
+          name: DHCLIENT_SET_HOSTNAME
+          value: "no"
+    services:
+      EC2-services:
+        - chronyd
+        - cloud-config
+        - cloud-final
+        - cloud-init
+        - cloud-init-local
+        - cloud-netconfig.timer

--- a/data/csp/gce/sle15/config.yaml
+++ b/data/csp/gce/sle15/config.yaml
@@ -1,34 +1,34 @@
 config:
-  files:
-    GCE-config:
-      - path: /etc/boto.cfg
-        append: True
-        content: "  ca_certificates_file = system" 
-      - path: /etc/boto.cfg.template
-        append: True
-        content: "  ca_certificates_file = system"
-      - path: /etc/default/instance_configs.cfg.distro
-        append: True
-        content: |-
-          [InstanceSetup]
-          set_boto_config = false
-  sysconfig:
-    GCE-sysconfig:
-      - file: /etc/sysconfig/network/config
-        name: NETCONFIG_MODULES_ORDER
-        value: "cloud-netconfig dns-resolver dns-bind dns-dnsmasq nis ntp-runtime"
-      - file: /etc/sysconfig/network/dhcp
-        name: DHCLIENT_SET_HOSTNAME
-        value: "yes"
-  services:
-    GCE-services:
-      - chronyd
-      - google-guest-agent
-      - google-osconfig-agent
-      - google-oslogin-cache.timer
-      - google-shutdown-scripts
-      - google-startup-scripts
-      - rootgrow
-  scripts:
+  config_script:
     GCE-config:
       - ssh-disable-password-login
+    files:
+      GCE-config:
+        - path: /etc/boto.cfg
+          append: True
+          content: "  ca_certificates_file = system"
+        - path: /etc/boto.cfg.template
+          append: True
+          content: "  ca_certificates_file = system"
+        - path: /etc/default/instance_configs.cfg.distro
+          append: True
+          content: |-
+            [InstanceSetup]
+            set_boto_config = false
+    sysconfig:
+      GCE-sysconfig:
+        - file: /etc/sysconfig/network/config
+          name: NETCONFIG_MODULES_ORDER
+          value: "cloud-netconfig dns-resolver dns-bind dns-dnsmasq nis ntp-runtime"
+        - file: /etc/sysconfig/network/dhcp
+          name: DHCLIENT_SET_HOSTNAME
+          value: "yes"
+    services:
+      GCE-services:
+        - chronyd
+        - google-guest-agent
+        - google-osconfig-agent
+        - google-oslogin-cache.timer
+        - google-shutdown-scripts
+        - google-startup-scripts
+        - rootgrow


### PR DESCRIPTION
The current way of describing script data was only done
for one script (config.sh) and does not allow to distinguish.
We also need support for creating (images.sh) and thus this
commit updates the scripts such that they follow the
implementation from SUSE-Enceladus/keg#37