### PR TITLE
Split EC2 data module

### DIFF
--- a/data/csp/ec2/addon/aws-sap-agent/sle12/overlayfiles.yaml
+++ b/data/csp/ec2/addon/aws-sap-agent/sle12/overlayfiles.yaml
@@ -1,0 +1,4 @@
+overlayfiles:
+  ec2-addon-aws-sap-agent:
+    include:
+      - script-install-aws-agent

--- a/data/csp/ec2/addon/aws-tools/sle12/packages.yaml
+++ b/data/csp/ec2/addon/aws-tools/sle12/packages.yaml
@@ -1,0 +1,11 @@
+packages:
+  image:
+    ec2-addon-aws-tools:
+      - amazon-ssm-agent
+      - aws-cli
+    ec2-addon-suse:
+      - cloud-netconfig-ec2
+      - python3-ec2metadata
+      - python-ec2deprecateimg
+      - python-ec2publishimg
+      - python-ec2uploadimg

--- a/data/csp/ec2/addon/aws-tools/sle15/packages.yaml
+++ b/data/csp/ec2/addon/aws-tools/sle15/packages.yaml
@@ -1,0 +1,10 @@
+packages:
+  image:
+    ec2-addon-aws-tools:
+      - amazon-ssm-agent
+      - aws-cli
+    ec2-addon-suse:
+      - cloud-init-config-suse
+      - cloud-netconfig-ec2
+      - python3-ec2imgutils
+      - python3-ec2metadata

--- a/data/csp/ec2/addon/ecs/sle15/packages.yaml
+++ b/data/csp/ec2/addon/ecs/sle15/packages.yaml
@@ -1,4 +1,4 @@
 packages:
   image:
-    ECS:
+    ec2-addon-ecs:
       - amazon-ecs-init

--- a/data/csp/ec2/sle15/packages.yaml
+++ b/data/csp/ec2/sle15/packages.yaml
@@ -1,15 +1,10 @@
 packages:
   image:
     EC2:
-      - aws-cli
       - cloud-init
-      - cloud-init-config-suse
-      - cloud-netconfig-ec2
       - name: grub2-x86_64-xen 
         arch: x86_64
       - kernel-default
-      - python3-ec2imgutils
-      - python3-ec2metadata
       - name: xen-libs
         arch: x86_64
       - name: xen-tools-domU

--- a/images/sles-sap/byos/profiles.yaml
+++ b/images/sles-sap/byos/profiles.yaml
@@ -12,6 +12,7 @@ profiles:
     description: EC2 HVM configuration
     include:
       - csp/ec2
+      - csp/ec2/addon/aws-tools
   GCE:
     description: GCE configuration
     include:

--- a/images/sles-sap/ondemand/profiles.yaml
+++ b/images/sles-sap/ondemand/profiles.yaml
@@ -11,6 +11,8 @@ profiles:
       - csp/azure/ondemand
   EC2-HVM:
     include:
+      - csp/ec2/addon/aws-tools
+      - csp/ec2/addon/aws-sap-agent
       - csp/ec2/ondemand
   GCE:
     include:

--- a/images/sles/byos/profiles.yaml
+++ b/images/sles/byos/profiles.yaml
@@ -10,7 +10,7 @@ profiles:
   EC2-HVM:
     description: EC2 HVM configuration
     include:
-      - csp/ec2
+      - csp/ec2/addon/aws-tools
   GCE:
     description: GCE configuration
     include:

--- a/images/sles/ec2-ecs/profiles.yaml
+++ b/images/sles/ec2-ecs/profiles.yaml
@@ -5,5 +5,6 @@ profiles:
       - base/jeos
       - base/sle-modules
       - base/sles
-      - csp/ec2/ecs
+      - csp/ec2/addon/aws-tools
+      - csp/ec2/addon/ecs
       - csp/ec2/ondemand

--- a/images/sles/hpc-byos/profiles.yaml
+++ b/images/sles/hpc-byos/profiles.yaml
@@ -12,3 +12,4 @@ profiles:
     description: EC2 HVM configuration
     include:
       - csp/ec2
+      - csp/ec2/addon/aws-tools

--- a/images/sles/hpc/profiles.yaml
+++ b/images/sles/hpc/profiles.yaml
@@ -13,4 +13,5 @@ profiles:
   EC2-HVM:
     description: EC2 HVM configuration
     include:
+      - csp/ec2/addon/aws-tools
       - csp/ec2/ondemand

--- a/images/sles/ondemand/profiles.yaml
+++ b/images/sles/ondemand/profiles.yaml
@@ -16,6 +16,7 @@ profiles:
   EC2-HVM:
     description: EC2 HVM configuration
     include:
+      - csp/ec2/addon/aws-tools
       - csp/ec2/ondemand
   GCE:
     description: GCE configuration

--- a/images/suse-manager/proxy/profiles.yaml
+++ b/images/suse-manager/proxy/profiles.yaml
@@ -10,6 +10,7 @@ profiles:
   EC2-HVM:
     include:
       - csp/ec2
+      - csp/ec2/addon/aws-tools
   GCE:
     include:
       - csp/gce

--- a/images/suse-manager/server/profiles.yaml
+++ b/images/suse-manager/server/profiles.yaml
@@ -10,6 +10,7 @@ profiles:
   EC2-HVM:
     include:
       - csp/ec2
+      - csp/ec2/addon/aws-tools
   GCE:
     include:
       - csp/gce


### PR DESCRIPTION
Moved packages from base EC2 module into csp/ec2/addon/aws-tool so CHOST canuse a stripped down set of EC2 packages.
Moved ECS module into csp/ec2/addon.
Added aws-sap-agent in csp/ec2/addon (will be used in SLE12 images).