### PR TITLE
Delete use of deprecated kiwi config function

### DIFF
--- a/schemas/config.sh.templ
+++ b/schemas/config.sh.templ
@@ -66,11 +66,6 @@ set -e
 #--------------------------------------
 echo "Configure image: [$kiwi_iname]..."
 
-#======================================
-# Setup the build keys
-#--------------------------------------
-suseImportBuildKey
-
 {% set common_profile = data['profiles']['common'] %}
 
 {%- if common_profile and common_profile['config'] %}


### PR DESCRIPTION
suseImportBuildKey is deprecated and done by zypper
via the --gpg-auto-import-keys option used when kiwi
calls the package manager