### PR TITLE
Delete use of deprecated kiwi config function

### DIFF
--- a/schemas/config_sh_header.templ
+++ b/schemas/config_sh_header.templ
@@ -31,8 +31,3 @@ set -e
 #--------------------------------------
 echo "Configure image: [$kiwi_iname]..."
 
-#======================================
-# Setup the build keys
-#--------------------------------------
-suseImportBuildKey
-


### PR DESCRIPTION
suseImportBuildKey is deprecated and done by zypper
via the --gpg-auto-import-keys option used when kiwi
calls the package manager