### PR TITLE
SAP: Move libvirt-client into addon/docker module

### DIFF
--- a/data/products/sap/addon/docker/sle15/packages.yaml
+++ b/data/products/sap/addon/docker/sle15/packages.yaml
@@ -2,3 +2,4 @@ packages:
   image:
     sles4sap-docker:
       - docker
+      - libvirt-client

--- a/data/products/sap/sle15/packages.yaml
+++ b/data/products/sap/sle15/packages.yaml
@@ -19,7 +19,6 @@ packages:
       - libgtk-2_0-0
       - libjpeg62
       - libpng12-0
-      - libvirt-client
       - libyui-qt
       - ocfs2-kmp-default
       - patterns-ha-ha_sles


### PR DESCRIPTION
This prevents libvirt-client from being added to Azure baremetal image descriptions.