### PR TITLE
Minor cleanup

### DIFF
--- a/data/base/common/sle12/config.yaml
+++ b/data/base/common/sle12/config.yaml
@@ -7,13 +7,6 @@ config:
       - set-prodlink
       - zypp-disable-delta-rpms
   files:
-    common-sysconfig:
-      - path: /etc/sysconfig/clock
-        append: True
-        content: |-
-          DEFAULT_TIMEZONE="Etc/UTC"
-          HWCLOCK="-u"
-          UTC="true"
     common-sysconfig-keyboard:
       - path: /etc/sysconfig/console
         append: True
@@ -21,13 +14,6 @@ config:
           CONSOLE_ENCODING="UTF-8"
           CONSOLE_FONT="lat9w-16.psfu"
           CONSOLE_SCREENMAP="trivial"
-      - path: /etc/sysconfig/keyboard
-        append: True
-        content: |-
-          
-          # The YaST-internal identifier of the attached keyboard.
-          #
-          YAST_KEYBOARD="english-us,pc104"
   services:
     common-services:
       - sshd

--- a/data/csp/sle12/config.yaml
+++ b/data/csp/sle12/config.yaml
@@ -24,10 +24,6 @@ config:
           #
           WHEELS="0"
   sysconfig:
-    used-fs-list:
-      - file: /etc/sysconfig/storage
-        name: USED_FS_LIST
-        value: "ext4"
     suse-firewall-rules:
       - file: /etc/sysconfig/SuSEfirewall2
         name: FW_LOAD_MODULES

--- a/data/csp/sle12/sp4/config.yaml
+++ b/data/csp/sle12/sp4/config.yaml
@@ -1,3 +1,0 @@
-config:
-  sysconfig:
-    used-fs-list: Null

--- a/images/sle-legacy/sles-sap-gce-byos/profiles.yaml
+++ b/images/sle-legacy/sles-sap-gce-byos/profiles.yaml
@@ -4,5 +4,4 @@ profiles:
       - base/common
       - base/sle
       - csp/gce/addon/gce-tools
-      - products/sap/addon/hana-net
       - products/sap/byos

--- a/images/sle-legacy/sles-sap-gce/profiles.yaml
+++ b/images/sle-legacy/sles-sap-gce/profiles.yaml
@@ -7,5 +7,4 @@ profiles:
       - base/sle-modules
       - csp/gce/addon/gce-tools
       - csp/gce/ondemand
-      - products/sap/addon/hana-net
       - products/sap/ondemand


### PR DESCRIPTION
This PR drops a few sysconfig settings that are basically ineffective and removes the SAP HANA network config settings from GCE SLE 12 image definitions that are intended for AWS only.