### PR TITLE
Add GCE profiles in images/cross-cloud/sle-hpc

### DIFF
--- a/images/cross-cloud/sle-hpc/byos/15-sp2/image.yaml
+++ b/images/cross-cloud/sle-hpc/byos/15-sp2/image.yaml
@@ -5,3 +5,5 @@ image:
   name: SLES15-SP2-HPC-BYOS
   specification: "SUSE Linux Enterprise HPC 15 SP2 guest image"
   version: 1.0.42
+profiles:
+  GCE: Null

--- a/images/cross-cloud/sle-hpc/byos/profiles.yaml
+++ b/images/cross-cloud/sle-hpc/byos/profiles.yaml
@@ -14,3 +14,7 @@ profiles:
     description: EC2 configuration
     include:
       - csp/ec2/addon/aws-tools
+  GCE:
+    description: GCE configuration
+    include:
+      - csp/gce/addon/gce-tools

--- a/images/cross-cloud/sle-hpc/ondemand/15-sp2/image.yaml
+++ b/images/cross-cloud/sle-hpc/ondemand/15-sp2/image.yaml
@@ -5,3 +5,5 @@ image:
   name: SLES15-SP2-HPC
   specification: "SUSE Linux Enterprise HPC 15 SP2 guest image"
   version: 1.0.42
+profiles:
+  GCE: Null

--- a/images/cross-cloud/sle-hpc/ondemand/profiles.yaml
+++ b/images/cross-cloud/sle-hpc/ondemand/profiles.yaml
@@ -19,3 +19,8 @@ profiles:
     include:
       - csp/ec2/addon/aws-tools
       - csp/ec2/ondemand
+  GCE:
+    description: GCE configuration
+    include:
+      - csp/gce/addon/gce-tools
+      - csp/gce/ondemand


### PR DESCRIPTION
This adds GCE profiles to the SLE 15 HPC image definitions from SP3.

I noticed that in the current GCE HPC image descriptions the package `tuned` is included. The other images only include this in SAP(CAL) images. This PR does not add `tuned`. If required, I'll add it in a follow-up PR.