### PR TITLE
Fix: include kernel-azure in SLE12 SP5 On-Demand profiles

### DIFF
--- a/data/csp/azure/addon/default-kernel/sle12/packages.yaml
+++ b/data/csp/azure/addon/default-kernel/sle12/packages.yaml
@@ -1,0 +1,5 @@
+packages:
+  image:
+    azure-kernel:
+      - name: kernel-default
+        arch: x86_64

--- a/data/csp/azure/sle12/packages.yaml
+++ b/data/csp/azure/sle12/packages.yaml
@@ -17,4 +17,3 @@ packages:
         arch: x86_64
       - name: grub2-arm64-efi
         arch: aarch64
-

--- a/data/csp/azure/sle12/sp5/packages.yaml
+++ b/data/csp/azure/sle12/sp5/packages.yaml
@@ -1,0 +1,3 @@
+packages:
+  image:
+    azure-kernel: Null

--- a/images/single-cloud/12-sp5/azure/profiles.yaml
+++ b/images/single-cloud/12-sp5/azure/profiles.yaml
@@ -19,6 +19,7 @@ profiles:
       description: SLES Standard On-Demand image
       include:
         - csp/azure/addon/azure-kernel
+        - csp/azure/ondemand/standard
         - products/sles/ondemand
     HPC-On-Demand:
       description: SLES HPC On-Demand image
@@ -28,11 +29,12 @@ profiles:
     SAP-On-Demand:
       description: SLES for SAP On-Demand image
       include:
-        - csp/azure/addon/azure-tools
+        - csp/azure/addon/default-kernel
         - products/sap/ondemand
   Base-BYOS:
     include:
       - csp/azure/addon/azure-tools
+      - csp/azure/addon/default-kernel
     BYOS:
       description: SLES BYOS image
       include:

--- a/images/single-cloud/12-sp5/gce/profiles.yaml
+++ b/images/single-cloud/12-sp5/gce/profiles.yaml
@@ -9,12 +9,10 @@ profiles:
     BYOS:
       description: SLES GCE On-Demand configuration
       include:
-        - csp/gce/addon/gce-tools
         - products/sles/byos
     SAP-BYOS:
       description: SLES of SAP GCE BYOS configuration
       include:
-        - csp/gce/addon/gce-tools
         - products/sap/byos
   Base-On-Demand:
     include:
@@ -25,10 +23,8 @@ profiles:
     On-Demand:
       description: SLES GCE BYOS configuration
       include:
-        - csp/gce/ondemand
         - products/sles/ondemand
     SAP-On-Demand:
       description: SLES of SAP GCE On-Demand configuration
       include:
-        - csp/gce/ondemand
         - products/sap/ondemand


### PR DESCRIPTION
Due to the new keg feature that allows image parameters to be in base profiles, common Azure modules could be moved into the base for reducing duplication in the output. However, that means key 'azure-kernel' was now included in 'Base-On-Demand' and thus cannot be overwritten in e.g. Standard-On-Demand (to select 'kernel-azure'). This commit fixes it by making 'kernel-default' an explicit include (only for SLE12 SP5).

Also cleanup SLE12 SP5 GCE profile (drop obsolete includes).

This admittedly isn't very pretty, but it's limited to SLE12 SP5. Support for profile parameters in base profiles (https://github.com/SUSE-Enceladus/keg/pull/67) to reduce duplication in overlay archives and to make `config.kiwi` and `config.sh` more compact introduced the issue that you can have keys defined in nested profiles that are shadowed by identical keys in the base profile. Not necessarily a problem, but it's rather easy to miss. `keg` should detect such a clash and print a warning.