### PR TITLE
Add support for billing tags

### DIFF
--- a/data/csp/azure/ondemand/basic/license.yaml
+++ b/data/csp/azure/ondemand/basic/license.yaml
@@ -1,3 +1,0 @@
-profile:
-  parameters:
-    vhdfixedtag: 00000000-0000-0000-0000-000000000000

--- a/data/csp/azure/ondemand/basic/variant-id/sle12/config.yaml
+++ b/data/csp/azure/ondemand/basic/variant-id/sle12/config.yaml
@@ -1,6 +1,0 @@
-config:
-  files:
-    azure-ondemand-basic-track-variant:
-      - path: /etc/os-release
-        append: True
-        content: VARIANT_ID="sles-basic"

--- a/data/csp/azure/ondemand/basic/variant-id/sle15/config.yaml
+++ b/data/csp/azure/ondemand/basic/variant-id/sle15/config.yaml
@@ -1,6 +1,0 @@
-config:
-  files:
-    azure-ondemand-basic-track-variant:
-      - path: /etc/os-release
-        append: True
-        content: VARIANT_ID="sles-basic"

--- a/data/csp/azure/ondemand/standard/license.yaml
+++ b/data/csp/azure/ondemand/standard/license.yaml
@@ -1,3 +1,0 @@
-profile:
-  parameters:
-    vhdfixedtag: 00000000-0000-0000-0000-000000000000

--- a/data/csp/gce/ondemand/license.yaml
+++ b/data/csp/gce/ondemand/license.yaml
@@ -1,3 +1,0 @@
-profile:
-  parameters:
-    gcelicense: 0123456789

--- a/images/cross-cloud/sle-hpc/byos/profiles.yaml
+++ b/images/cross-cloud/sle-hpc/byos/profiles.yaml
@@ -10,6 +10,7 @@ profiles:
     include:
       - csp/azure/addon/azure-tools
       - csp/azure/addon/waagent-rdma
+      - csp/azure/byos/hpc
   EC2:
     description: EC2 configuration
     include:
@@ -18,3 +19,4 @@ profiles:
     description: GCE configuration
     include:
       - csp/gce/addon/gce-tools
+      - csp/gce/byos/hpc

--- a/images/cross-cloud/sle-hpc/ondemand/profiles.yaml
+++ b/images/cross-cloud/sle-hpc/ondemand/profiles.yaml
@@ -10,7 +10,7 @@ profiles:
   Azure:
     description: Azure configuration
     include:
-      - csp/azure/ondemand
+      - csp/azure/ondemand/hpc
       - csp/azure/addon/azure-kernel
       - csp/azure/addon/azure-tools
       - csp/azure/addon/waagent-rdma
@@ -23,4 +23,4 @@ profiles:
     description: GCE configuration
     include:
       - csp/gce/addon/gce-tools
-      - csp/gce/ondemand
+      - csp/gce/ondemand/hpc

--- a/images/cross-cloud/sles-sap/byos/profiles.yaml
+++ b/images/cross-cloud/sles-sap/byos/profiles.yaml
@@ -8,6 +8,7 @@ profiles:
     description: Azure configuration
     include:
       - csp/azure/addon/azure-tools
+      - csp/azure/byos/sap
   EC2:
     description: EC2 configuration
     include:
@@ -18,3 +19,4 @@ profiles:
       - csp/gce/addon/fence-agent-deps
       - csp/gce/addon/gce-tools
       - csp/gce/addon/google-auth
+      - csp/gce/byos/sap

--- a/images/cross-cloud/sles-sap/ondemand/profiles.yaml
+++ b/images/cross-cloud/sles-sap/ondemand/profiles.yaml
@@ -9,7 +9,7 @@ profiles:
   Azure:
     include:
       - csp/azure/addon/azure-tools
-      - csp/azure/ondemand
+      - csp/azure/ondemand/sap
   EC2:
     include:
       - csp/ec2/addon/aws-tools
@@ -19,4 +19,4 @@ profiles:
       - csp/gce/addon/fence-agent-deps
       - csp/gce/addon/gce-tools
       - csp/gce/addon/google-auth
-      - csp/gce/ondemand
+      - csp/gce/ondemand/sap

--- a/images/cross-cloud/sles/byos/profiles.yaml
+++ b/images/cross-cloud/sles/byos/profiles.yaml
@@ -8,6 +8,7 @@ profiles:
     description: Azure configuration
     include:
       - csp/azure/addon/azure-tools
+      - csp/azure/byos/sles
   EC2:
     description: EC2 configuration
     include:
@@ -16,3 +17,4 @@ profiles:
     description: GCE configuration
     include:
       - csp/gce/addon/gce-tools
+      - csp/gce/byos/sles

--- a/images/cross-cloud/sles/chost/profiles.yaml
+++ b/images/cross-cloud/sles/chost/profiles.yaml
@@ -12,6 +12,7 @@ profiles:
     description: Azure configuration
     include:
       - csp/azure/addon/chost-tweaks
+      - csp/azure/byos/sles
       - kernel-options/cgroup-memory
   EC2:
     description: EC2 configuration
@@ -21,7 +22,7 @@ profiles:
   GCE:
     description: GCE configuration
     include:
-      - csp/gce
+      - csp/gce/byos/sles
       - kernel-options/cgroup-memory
   OpenStack:
     description: OpenStack configuration

--- a/images/cross-cloud/sles/ondemand/profiles.yaml
+++ b/images/cross-cloud/sles/ondemand/profiles.yaml
@@ -13,7 +13,7 @@ profiles:
     Azure-Basic:
       description: Azure configuration
       include:
-        - csp/azure/ondemand/basic/variant-id
+        - csp/azure/ondemand/basic
     Azure-Standard:
       description: Azure configuration
       include:
@@ -27,4 +27,4 @@ profiles:
     description: GCE configuration
     include:
       - csp/gce/addon/gce-tools
-      - csp/gce/ondemand
+      - csp/gce/ondemand/sles

--- a/images/cross-cloud/sles/sapcal/profiles.yaml
+++ b/images/cross-cloud/sles/sapcal/profiles.yaml
@@ -11,7 +11,7 @@ profiles:
     description: Azure configuration
     include:
       - csp/azure/addon/azure-tools
-      - csp/azure/ondemand/basic
+      - csp/azure/ondemand/sapcal
   EC2:
     description: EC2 configuration
     include:
@@ -21,4 +21,4 @@ profiles:
     description: GCE configuration
     include:
       - csp/gce/addon/gce-tools
-      - csp/gce/ondemand
+      - csp/gce/ondemand/sapcal

--- a/images/cross-cloud/suse-manager/proxy/profiles.yaml
+++ b/images/cross-cloud/suse-manager/proxy/profiles.yaml
@@ -13,3 +13,4 @@ profiles:
   GCE:
     include:
       - csp/gce/addon/gce-tools
+      - csp/gce/byos/suma-proxy

--- a/images/cross-cloud/suse-manager/server/profiles.yaml
+++ b/images/cross-cloud/suse-manager/server/profiles.yaml
@@ -13,3 +13,4 @@ profiles:
   GCE:
     include:
       - csp/gce/addon/gce-tools
+      - csp/gce/byos/suma-server

--- a/images/single-cloud/12-sp5/azure/profiles.yaml
+++ b/images/single-cloud/12-sp5/azure/profiles.yaml
@@ -25,11 +25,14 @@ profiles:
       description: SLES HPC On-Demand image
       include:
         - csp/azure/addon/azure-kernel
+        - csp/azure/ondemand/hpc
         - products/hpc/ondemand
     SAP-On-Demand:
       description: SLES for SAP On-Demand image
       include:
+        - csp/azure/addon/azure-tools
         - csp/azure/addon/default-kernel
+        - csp/azure/ondemand/sap
         - products/sap/ondemand
   Base-BYOS:
     include:
@@ -38,12 +41,15 @@ profiles:
     BYOS:
       description: SLES BYOS image
       include:
+        - csp/azure/byos/sles
         - products/sles/byos
     HPC-BYOS:
       description: SLES HPC BYOS image
       include:
+        - csp/azure/byos/hpc
         - products/hpc/byos
     SAP-BYOS:
       description: SLES for SAP BYOS image
       include:
+        - csp/azure/byos/sap
         - products/sap/byos

--- a/images/single-cloud/12-sp5/gce/profiles.yaml
+++ b/images/single-cloud/12-sp5/gce/profiles.yaml
@@ -9,10 +9,12 @@ profiles:
     BYOS:
       description: SLES GCE On-Demand configuration
       include:
+        - csp/gce/byos/sles
         - products/sles/byos
     SAP-BYOS:
       description: SLES of SAP GCE BYOS configuration
       include:
+        - csp/gce/byos/sap
         - products/sap/byos
   Base-On-Demand:
     include:
@@ -23,8 +25,10 @@ profiles:
     On-Demand:
       description: SLES GCE BYOS configuration
       include:
+        - csp/gce/ondemand/sles
         - products/sles/ondemand
     SAP-On-Demand:
       description: SLES of SAP GCE On-Demand configuration
       include:
+        - csp/gce/ondemand/sap
         - products/sap/ondemand

--- a/images/single-cloud/sle-hpc-azure/15-sp1/image.yaml
+++ b/images/single-cloud/sle-hpc-azure/15-sp1/image.yaml
@@ -4,14 +4,3 @@ image:
   name: SLES15-SP1-Azure-HPC-BYOS
   specification: "SUSE Linux Enterprise HPC 15 SP1 guest image for Microsoft Azure"
   version: 1.0.42
-profiles:
-  common:
-    include:
-      - base/hpc
-      - base/common
-      - base/sle
-      - csp/azure/addon/azure-tools
-      - csp/azure/addon/waagent-rdma
-      - products/hpc/byos
-  Azure: Null
-  EC2: Null

--- a/images/single-cloud/sle-hpc-azure/profiles.yaml
+++ b/images/single-cloud/sle-hpc-azure/profiles.yaml
@@ -5,4 +5,5 @@ profiles:
       - base/sle
       - csp/azure/addon/azure-tools
       - csp/azure/addon/waagent-rdma
+      - csp/azure/byos/hpc
       - products/hpc/byos

--- a/images/single-cloud/sles-azure-byos/profiles.yaml
+++ b/images/single-cloud/sles-azure-byos/profiles.yaml
@@ -4,4 +4,5 @@ profiles:
       - base/common
       - base/sle
       - csp/azure/addon/azure-tools
+      - csp/azure/byos/sles
       - products/sles/byos

--- a/images/single-cloud/sles-gce-byos/profiles.yaml
+++ b/images/single-cloud/sles-gce-byos/profiles.yaml
@@ -4,4 +4,5 @@ profiles:
       - base/common
       - base/sle
       - csp/gce/addon/gce-tools
+      - csp/gce/byos/sles
       - products/sles/byos

--- a/images/single-cloud/sles-sap-azure-byos/profiles.yaml
+++ b/images/single-cloud/sles-sap-azure-byos/profiles.yaml
@@ -4,4 +4,5 @@ profiles:
       - base/common
       - base/sle
       - csp/azure/addon/azure-tools
+      - csp/azure/byos/sap
       - products/sap/byos

--- a/images/single-cloud/sles-sap-azure/profiles.yaml
+++ b/images/single-cloud/sles-sap-azure/profiles.yaml
@@ -6,5 +6,5 @@ profiles:
       - base/sle
       - base/sle-modules
       - csp/azure/addon/azure-tools
-      - csp/azure/ondemand
+      - csp/azure/ondemand/sap
       - products/sap/ondemand

--- a/images/single-cloud/sles-sap-gce-byos/profiles.yaml
+++ b/images/single-cloud/sles-sap-gce-byos/profiles.yaml
@@ -4,4 +4,5 @@ profiles:
       - base/common
       - base/sle
       - csp/gce/addon/gce-tools
+      - csp/gce/byos/sap
       - products/sap/byos

--- a/images/single-cloud/sles-sap-gce/profiles.yaml
+++ b/images/single-cloud/sles-sap-gce/profiles.yaml
@@ -6,5 +6,5 @@ profiles:
       - base/sle
       - base/sle-modules
       - csp/gce/addon/gce-tools
-      - csp/gce/ondemand
+      - csp/gce/ondemand/sap
       - products/sap/ondemand


### PR DESCRIPTION
This drops the fake billing tags and modifies the image definitions to include product specific csp module extensions. This allows for including of billing tags from a private repository. If not available, generated image descriptions will simply lack those.

Also contains a couple of minor fixes in image definitions.