### PR TITLE
Use old style bootloader parameters for SLE15 <=SP1

### DIFF
--- a/data/csp/azure/sle15/profile.yaml
+++ b/data/csp/azure/sle15/profile.yaml
@@ -1,7 +1,6 @@
 profile:
-  bootloader:
-    console: serial
   parameters:
+    bootloader_console: serial
     bootpartition: "true"
     bootpartsize: 1024
     devicepersistency: by-uuid

--- a/data/csp/gce/sle15/profile.yaml
+++ b/data/csp/gce/sle15/profile.yaml
@@ -1,7 +1,6 @@
 profile:
-  bootloader:
-    console: serial
   parameters:
+    bootloader_console: serial
     format: gce
     kernelcmdline:
       console: ttyS0,38400n8

--- a/data/csp/gce/sle15/sp2/profile.yaml
+++ b/data/csp/gce/sle15/sp2/profile.yaml
@@ -1,7 +1,5 @@
 profile:
   bootloader:
     console: serial
-    timeout_style: countdown
   parameters:
     bootloader_console: Null
-    firmware: uefi

--- a/data/csp/sle15/profile_defaults.yaml
+++ b/data/csp/sle15/profile_defaults.yaml
@@ -1,9 +1,8 @@
 profile:
-  bootloader:
-    name: grub2
-    timeout: 1
   parameters:
+    bootloader: grub2
     bootpartition: "false"
+    boottimeout: 1
     firmware: uefi
     devicepersistency: by-label
     filesystem: xfs

--- a/data/csp/sle15/sp2/profile_defaults.yaml
+++ b/data/csp/sle15/sp2/profile_defaults.yaml
@@ -1,0 +1,7 @@
+profile:
+  bootloader:
+    name: grub2
+    timeout: 1
+  parameters:
+    bootloader: Null
+    boottimeout: Null


### PR DESCRIPTION
Use old style bootloader parameters (i.e. inside the `type` tag rather than in its own section) for SLE15 <=SP1 image descriptions, in line with existing descriptions.

This change is probably just cosmetic (correct me if I'm wrong @schaefi), so we could also consider not to merge it to keep it a little simpler.