### PR TITLE
Add libxml2 to Azure VLI SLES 15 <=SP1

### DIFF
--- a/data/csp/azure-baremetal/vli/sle15/packages.yaml
+++ b/data/csp/azure-baremetal/vli/sle15/packages.yaml
@@ -2,3 +2,6 @@ packages:
   image:
     azure-vli-patch:
       - patch
+    azure-vli-libxml:
+      - libxml2
+      - libxml2-32bit

--- a/data/csp/azure-baremetal/vli/sle15/sp2/packages.yaml
+++ b/data/csp/azure-baremetal/vli/sle15/sp2/packages.yaml
@@ -1,3 +1,4 @@
 packages:
   image:
     azure-vli-patch: Null
+    azure-vli-libxml: Null


### PR DESCRIPTION
Add libxml2 and libxml2-32bit to Azure VLI SLES 15 GA and SP1, in line with configuration in azure-li-services repository.