### PR TITLE
Do not set boottimeout in SLE15 Azure baremetal

### DIFF
--- a/data/csp/azure-baremetal/sle15/profile.yaml
+++ b/data/csp/azure-baremetal/sle15/profile.yaml
@@ -2,6 +2,7 @@ profile:
   parameters:
     bootloader: grub2
     bootpartition: "false"
+    boottimeout: Null
     devicepersistency: Null
     initrd_system: dracut
     kernelcmdline:


### PR DESCRIPTION
https://github.com/SUSE-Enceladus/keg-recipes/pull/49 sets a default "old style" `boottimeout` paramater for SLE15 <=SP1 that is unwanted in Azure LI/VLI. This PR clears the parameter in the azure-baremetal module.