### PR TITLE
Use UEFI in SLE15 Azure SAPCAL

### DIFF
--- a/data/csp/azure/ondemand/sapcal/sle15/packages.yaml
+++ b/data/csp/azure/ondemand/sapcal/sle15/packages.yaml
@@ -1,0 +1,5 @@
+packages:
+  image:
+    azure-shim:
+      - name: shim
+        arch: x86_64

--- a/data/csp/azure/ondemand/sapcal/sle15/profile.yaml
+++ b/data/csp/azure/ondemand/sapcal/sle15/profile.yaml
@@ -1,0 +1,3 @@
+profile:
+  parameters:
+    firmware: uefi


### PR DESCRIPTION
This really affects only SLES 15 SP1 SAPCAL for Azure. It switches the boot firmware to UEFI, in line with released image. The other SLES 15 SP1 Azure images use EFI.