### PR TITLE
Disable iscsid service in HPC SLE15 SP3+

### DIFF
--- a/data/products/hpc/sle15/sp3/config.yaml
+++ b/data/products/hpc/sle15/sp3/config.yaml
@@ -1,0 +1,5 @@
+config:
+  services:
+    hpc-iscsid:
+      - name: iscsid
+        enable: False


### PR DESCRIPTION
Disables iscsid service in HPC images from SLE15 SP3, in line with the released images.