### PR TITLE
Add grub2 efi package to LI/VLI

### DIFF
--- a/data/csp/azure-baremetal/sle15/packages.yaml
+++ b/data/csp/azure-baremetal/sle15/packages.yaml
@@ -5,6 +5,8 @@ packages:
       - azure-li-services
       - dracut-kiwi-oem-repart
       - gconf2
+      - name: grub2-x86_64-efi
+        arch: x86_64
       - hyper-v
       - icmpinfo
       - kernel-default


### PR DESCRIPTION
Explicitly use the architecture appropriate grub efi package. Automatic  dependency resolution in the build service triggers an unresolvable.