### PR TITLE
Add missing keyword to csp/gce/sle12/overlayfiles.yaml

### DIFF
--- a/data/csp/gce/sle12/overlayfiles.yaml
+++ b/data/csp/gce/sle12/overlayfiles.yaml
@@ -4,4 +4,5 @@ overlayfiles:
       - gce-boto-hack
       - hosts-metadata-google
   gce-sysconfig-network:
+    include:
       - sysconfig-network-plain


### PR DESCRIPTION
Add missing `include` keyword.