### PR TITLE
Set rpm-excludedocs in CHOST SLE15 SP2+

### DIFF
--- a/data/products/chost/sle15/sp2/preferences.yaml
+++ b/data/products/chost/sle15/sp2/preferences.yaml
@@ -1,0 +1,2 @@
+preferences:
+  rpm-excludedocs: "true"

--- a/schemas/vm.kiwi.templ
+++ b/schemas/vm.kiwi.templ
@@ -35,6 +35,11 @@
         <locale>en_US</locale>
         <keytable>us.map.gz</keytable>
         <timezone>UTC</timezone>
+    {%- if data['profiles']['common'] %}
+    {%-     for pref in data['profiles']['common']['preferences'] %}
+        <{{ pref }}>{{ data['profiles']['common']['preferences'][pref] }}</{{ pref }}>
+    {%-     endfor %}
+    {%- endif %}
     {%- if not multibuild %}
         {{ macros.print_preferences(data['profiles']['common']['profile']) }}
     {%- endif %}


### PR DESCRIPTION
Adds support for configurable global preferences tags and uses that feature to set `rpm-excludedocs` for CHOST images (SLE15 SP2+).