### PR TITLE
Fix OBS multibuild comment for EC2-ECS

### DIFF
--- a/images/cross-cloud/sles/ec2-ecs/obs-comments.yaml
+++ b/images/cross-cloud/sles/ec2-ecs/obs-comments.yaml
@@ -1,2 +1,3 @@
 image-config-comments:
   obs-archs: "OBS-ExclusiveArch: x86_64 aarch64"
+  obs-multibuild: Null


### PR DESCRIPTION
Clear OBS multibuild comment, otherwise image won't build.

As a note, this and the Azure LI/VLI images are perhaps a little misplaced since the image descriptions were moved under the `cross-cloud` top level directory, since they're not actually cross-cloud. We could move them over to `single-cloud`.