### PR TITLE
- Add apparmor-parser to Server 15 images (bsc#1192171)

### DIFF
--- a/data/products/chost/sle15/packages.yaml
+++ b/data/products/chost/sle15/packages.yaml
@@ -1,6 +1,7 @@
 packages:
   image:
     chost:
+      - apparmor-parser
       - bind-utils
       - ca-certificates
       - ca-certificates-mozilla

--- a/data/products/sles/sle15/packages.yaml
+++ b/data/products/sles/sle15/packages.yaml
@@ -1,6 +1,7 @@
 packages:
   image:
     sles:
+      - apparmor-parser
       - docker
       - release-notes-sles
   bootstrap:


### PR DESCRIPTION
  + Supports the installation of rke2 and k3s without having to have
    the instance registered.