### PR TITLE
Minor cleanup in data/csp/aliyun

### DIFF
--- a/data/csp/aliyun/sle15/sp2/overlayfiles.yaml
+++ b/data/csp/aliyun/sle15/sp2/overlayfiles.yaml
@@ -1,2 +1,0 @@
-overlayfiles:
-  gce-grub: null


### PR DESCRIPTION
Drop pointless file `data/csp/aliyun/sle15/sp2/overlayfiles.yaml`. It's a left-over from when I added aliyun module based on the gce module, and I obviously forgot to remove this file.