### PR TITLE
Add package 'shim' to SLE15 profile defaults

### DIFF
--- a/data/csp/aliyun/sle15/packages.yaml
+++ b/data/csp/aliyun/sle15/packages.yaml
@@ -4,3 +4,4 @@ packages:
       - cloud-init
       - kernel-default
     bootloader-efi: Null
+    bootloader-shim: Null

--- a/data/csp/azure-baremetal/sle15/packages.yaml
+++ b/data/csp/azure-baremetal/sle15/packages.yaml
@@ -17,7 +17,6 @@ packages:
       - prctl
       - procinfo
       - rsh
-      - shim
       - syslinux
       - targetcli-fb-common
       - ucode-intel

--- a/data/csp/azure/sle15/packages.yaml
+++ b/data/csp/azure/sle15/packages.yaml
@@ -12,3 +12,4 @@ packages:
     azure-kernel:
       - name: kernel-default
         arch: x86_64
+    bootloader-shim: Null

--- a/data/csp/gce/sle15/packages.yaml
+++ b/data/csp/gce/sle15/packages.yaml
@@ -8,8 +8,6 @@ packages:
       - growpart
       - growpart-rootgrow
       - kernel-default
-      - name: shim
-        arch: x86_64
     gce-patch:
       # bsc#1165960
       - patch

--- a/data/csp/openstack/sle15/packages.yaml
+++ b/data/csp/openstack/sle15/packages.yaml
@@ -4,3 +4,4 @@ packages:
       - cloud-init
       - kernel-default
     bootloader-efi: Null
+    bootloader-shim: Null

--- a/data/csp/sle15/profile_defaults.yaml
+++ b/data/csp/sle15/profile_defaults.yaml
@@ -18,6 +18,9 @@ packages:
         arch: x86_64
       - name: grub2-arm64-efi
         arch: aarch64
+    bootloader-shim:
+      - name: shim
+        arch: x86_64
 config:
   services:
     vm-services:


### PR DESCRIPTION
Adds `shim` to `data/csp/sle15/profile_defaults.yaml` and removes it from GCE and Azure Baremetal modules, as it's not needed there anymore. It also disables it in Aliyun, OpenStack, and partly in Azure.

This serves two purposes. First, it adds shim to EC2 image descriptions, which were switched to UEFI by https://github.com/SUSE-Enceladus/keg-recipes/pull/70 but I forgot to add the package. Second, it adds shim to the CSP SLE15 profile defaults. Since those defaults include setting boot firmware to `uefi`, it seems logical to include shim as well.