### PR TITLE
Avoid duplicate package sections in SLES 15 for Azure

### DIFF
--- a/images/cross-cloud/sles/ondemand/profiles.yaml
+++ b/images/cross-cloud/sles/ondemand/profiles.yaml
@@ -10,6 +10,7 @@ profiles:
     include:
       - csp/azure/addon/azure-kernel
       - csp/azure/addon/azure-tools
+      - csp/azure/ondemand
     Azure-Basic:
       description: Azure configuration
       include:


### PR DESCRIPTION
Include csp/azure/ondemand in SLES 15 on-demand Azure base profile, so all packages get included in shared package section.