### PR TITLE
Add start and end comments to generate-motd.sh

### DIFF
--- a/data/scripts/generate-motd.sh
+++ b/data/scripts/generate-motd.sh
@@ -1,3 +1,5 @@
+# Start generate /etc/motd
+#
 source /etc/os-release
 
 OS_PRETTY_NAME="$PRETTY_NAME"
@@ -46,3 +48,5 @@ done
 
 test -d /etc/motd.d && rm -r /etc/motd.d
 test -f /etc/motd-caption && rm /etc/motd-caption
+#
+# End generate /etc/motd


### PR DESCRIPTION
This adds start and end comments to the `generate-motd.sh` snippet for better readability in final `config.sh`.