### PR TITLE
Set appropriate kiwi 'schemaversion' in all images

### DIFF
--- a/images/cross-cloud/sle-hpc/byos/15-sp2/image.yaml
+++ b/images/cross-cloud/sle-hpc/byos/15-sp2/image.yaml
@@ -1,6 +1,7 @@
 include-paths:
   - sle15/sp1
   - sle15/sp2
+schemaversion: 7.2
 image:
   name: SLES15-SP2-HPC-BYOS
   specification: "SUSE Linux Enterprise HPC 15 SP2 guest image"

--- a/images/cross-cloud/sle-hpc/byos/15-sp3/image.yaml
+++ b/images/cross-cloud/sle-hpc/byos/15-sp3/image.yaml
@@ -2,6 +2,7 @@ include-paths:
   - sle15/sp1
   - sle15/sp2
   - sle15/sp3
+schemaversion: 7.2
 image:
   name: SLES15-SP3-HPC-BYOS
   specification: "SUSE Linux Enterprise HPC 15 SP3 guest image"

--- a/images/cross-cloud/sle-hpc/byos/15-sp4/image.yaml
+++ b/images/cross-cloud/sle-hpc/byos/15-sp4/image.yaml
@@ -3,6 +3,7 @@ include-paths:
   - sle15/sp2
   - sle15/sp3
   - sle15/sp4
+schemaversion: 7.2
 image:
   name: SLES15-SP4-HPC-BYOS
   specification: "SUSE Linux Enterprise HPC 15 SP4 guest image"

--- a/images/cross-cloud/sle-hpc/ondemand/15-sp2/image.yaml
+++ b/images/cross-cloud/sle-hpc/ondemand/15-sp2/image.yaml
@@ -1,6 +1,7 @@
 include-paths:
   - sle15/sp1
   - sle15/sp2
+schemaversion: 7.2
 image:
   name: SLES15-SP2-HPC
   specification: "SUSE Linux Enterprise HPC 15 SP2 guest image"

--- a/images/cross-cloud/sle-hpc/ondemand/15-sp3/image.yaml
+++ b/images/cross-cloud/sle-hpc/ondemand/15-sp3/image.yaml
@@ -2,6 +2,7 @@ include-paths:
   - sle15/sp1
   - sle15/sp2
   - sle15/sp3
+schemaversion: 7.2
 image:
   name: SLES15-SP3-HPC
   specification: "SUSE Linux Enterprise HPC 15 SP3 guest image"

--- a/images/cross-cloud/sle-hpc/ondemand/15-sp4/image.yaml
+++ b/images/cross-cloud/sle-hpc/ondemand/15-sp4/image.yaml
@@ -3,6 +3,7 @@ include-paths:
   - sle15/sp2
   - sle15/sp3
   - sle15/sp4
+schemaversion: 7.2
 image:
   name: SLES15-SP4-HPC
   specification: "SUSE Linux Enterprise HPC 15 SP4 guest image"

--- a/images/cross-cloud/sles-sap/azure-li/15-sp2/image.yaml
+++ b/images/cross-cloud/sles-sap/azure-li/15-sp2/image.yaml
@@ -1,6 +1,7 @@
 include-paths:
   - sle15/sp1
   - sle15/sp2
+schemaversion: 7.2
 image:
   name: SLES15-SP2-SAP-Azure-LI-BYOS
   specification: "SUSE Linux Enterprise Server for SAP Applications 15 SP2 Azure LI BYOS guest image"

--- a/images/cross-cloud/sles-sap/azure-li/15-sp3/image.yaml
+++ b/images/cross-cloud/sles-sap/azure-li/15-sp3/image.yaml
@@ -2,6 +2,7 @@ include-paths:
   - sle15/sp1
   - sle15/sp2
   - sle15/sp3
+schemaversion: 7.2
 image:
   name: SLES15-SP3-SAP-Azure-LI-BYOS
   specification: "SUSE Linux Enterprise Server for SAP Applications 15 SP3 Azure LI BYOS guest image"

--- a/images/cross-cloud/sles-sap/azure-li/15-sp4/image.yaml
+++ b/images/cross-cloud/sles-sap/azure-li/15-sp4/image.yaml
@@ -3,6 +3,7 @@ include-paths:
   - sle15/sp2
   - sle15/sp3
   - sle15/sp4
+schemaversion: 7.2
 image:
   name: SLES15-SP4-SAP-Azure-LI-BYOS
   specification: "SUSE Linux Enterprise Server for SAP Applications 15 SP4 Azure LI BYOS guest image"

--- a/images/cross-cloud/sles-sap/azure-vli/15-sp2/image.yaml
+++ b/images/cross-cloud/sles-sap/azure-vli/15-sp2/image.yaml
@@ -1,6 +1,7 @@
 include-paths:
   - sle15/sp1
   - sle15/sp2
+schemaversion: 7.2
 image:
   name: SLES15-SP2-SAP-Azure-VLI-BYOS
   specification: "SUSE Linux Enterprise Server for SAP Applications 15 SP2 Azure VLI BYOS guest image"

--- a/images/cross-cloud/sles-sap/azure-vli/15-sp3/image.yaml
+++ b/images/cross-cloud/sles-sap/azure-vli/15-sp3/image.yaml
@@ -2,6 +2,7 @@ include-paths:
   - sle15/sp1
   - sle15/sp2
   - sle15/sp3
+schemaversion: 7.2
 image:
   name: SLES15-SP3-SAP-Azure-VLI-BYOS
   specification: "SUSE Linux Enterprise Server for SAP Applications 15 SP3 Azure VLI BYOS guest image"

--- a/images/cross-cloud/sles-sap/azure-vli/15-sp4/image.yaml
+++ b/images/cross-cloud/sles-sap/azure-vli/15-sp4/image.yaml
@@ -3,6 +3,7 @@ include-paths:
   - sle15/sp2
   - sle15/sp3
   - sle15/sp4
+schemaversion: 7.2
 image:
   name: SLES15-SP4-SAP-Azure-VLI-BYOS
   specification: "SUSE Linux Enterprise Server for SAP Applications 15 SP4 Azure VLI BYOS guest image"

--- a/images/cross-cloud/sles-sap/byos/15-sp2/image.yaml
+++ b/images/cross-cloud/sles-sap/byos/15-sp2/image.yaml
@@ -1,6 +1,7 @@
 include-paths:
   - sle15/sp1
   - sle15/sp2
+schemaversion: 7.2
 image:
   name: SLES15-SP2-SAP-BYOS
   specification: "SUSE Linux Enterprise Server for SAP Applications 15 SP2 BYOS guest image"

--- a/images/cross-cloud/sles-sap/byos/15-sp3/image.yaml
+++ b/images/cross-cloud/sles-sap/byos/15-sp3/image.yaml
@@ -2,6 +2,7 @@ include-paths:
   - sle15/sp1
   - sle15/sp2
   - sle15/sp3
+schemaversion: 7.2
 image:
   name: SLES15-SP3-SAP-BYOS
   specification: "SUSE Linux Enterprise Server for SAP Applications 15 SP3 BYOS guest image"

--- a/images/cross-cloud/sles-sap/byos/15-sp4/image.yaml
+++ b/images/cross-cloud/sles-sap/byos/15-sp4/image.yaml
@@ -3,6 +3,7 @@ include-paths:
   - sle15/sp2
   - sle15/sp3
   - sle15/sp4
+schemaversion: 7.2
 image:
   name: SLES15-SP4-SAP-BYOS
   specification: "SUSE Linux Enterprise Server for SAP Applications 15 SP4 BYOS guest image"

--- a/images/cross-cloud/sles-sap/ondemand/15-sp2/image.yaml
+++ b/images/cross-cloud/sles-sap/ondemand/15-sp2/image.yaml
@@ -1,6 +1,7 @@
 include-paths:
   - sle15/sp1
   - sle15/sp2
+schemaversion: 7.2
 image:
   name: SLES15-SP2-SAP
   specification: "SUSE Linux Enterprise Server for SAP Applications 15 SP2 guest image"

--- a/images/cross-cloud/sles-sap/ondemand/15-sp3/image.yaml
+++ b/images/cross-cloud/sles-sap/ondemand/15-sp3/image.yaml
@@ -2,6 +2,7 @@ include-paths:
   - sle15/sp1
   - sle15/sp2
   - sle15/sp3
+schemaversion: 7.2
 image:
   name: SLES15-SP3-SAP
   specification: "SUSE Linux Enterprise Server for SAP Applications 15 SP3 guest image"

--- a/images/cross-cloud/sles-sap/ondemand/15-sp4/image.yaml
+++ b/images/cross-cloud/sles-sap/ondemand/15-sp4/image.yaml
@@ -3,6 +3,7 @@ include-paths:
   - sle15/sp2
   - sle15/sp3
   - sle15/sp4
+schemaversion: 7.2
 image:
   name: SLES15-SP4-SAP
   specification: "SUSE Linux Enterprise Server for SAP Applications 15 SP4 guest image"

--- a/images/cross-cloud/sles/byos/15-sp2/image.yaml
+++ b/images/cross-cloud/sles/byos/15-sp2/image.yaml
@@ -1,6 +1,7 @@
 include-paths:
   - sle15/sp1
   - sle15/sp2
+schemaversion: 7.2
 image:
   name: SLES15-SP2-BYOS
   specification: "SUSE Linux Enterprise Server 15 SP2 BYOS guest image"

--- a/images/cross-cloud/sles/byos/15-sp3/image.yaml
+++ b/images/cross-cloud/sles/byos/15-sp3/image.yaml
@@ -2,6 +2,7 @@ include-paths:
   - sle15/sp1
   - sle15/sp2
   - sle15/sp3
+schemaversion: 7.2
 image:
   name: SLES15-SP3-BYOS
   specification: "SUSE Linux Enterprise Server 15 SP3 BYOS guest image"

--- a/images/cross-cloud/sles/byos/15-sp4/image.yaml
+++ b/images/cross-cloud/sles/byos/15-sp4/image.yaml
@@ -3,6 +3,7 @@ include-paths:
   - sle15/sp2
   - sle15/sp3
   - sle15/sp4
+schemaversion: 7.2
 image:
   name: SLES15-SP4-BYOS
   specification: "SUSE Linux Enterprise Server 15 SP4 BYOS guest image"

--- a/images/cross-cloud/sles/chost/15-sp1/image.yaml
+++ b/images/cross-cloud/sles/chost/15-sp1/image.yaml
@@ -1,5 +1,6 @@
 include-paths:
   - sle15/sp1
+schemaversion: 7.1
 image:
   name: SLES15-SP1-CHOST-BYOS
   specification: "SUSE Linux Enterprise Server 15 SP1 BYOS guest image optimized as container host"

--- a/images/cross-cloud/sles/chost/15-sp2/image.yaml
+++ b/images/cross-cloud/sles/chost/15-sp2/image.yaml
@@ -1,6 +1,7 @@
 include-paths:
   - sle15/sp1
   - sle15/sp2
+schemaversion: 7.2
 image:
   name: SLES15-SP2-CHOST-BYOS
   specification: "SUSE Linux Enterprise Server 15 SP2 BYOS guest image optimized as container host"

--- a/images/cross-cloud/sles/chost/15-sp3/image.yaml
+++ b/images/cross-cloud/sles/chost/15-sp3/image.yaml
@@ -2,6 +2,7 @@ include-paths:
   - sle15/sp1
   - sle15/sp2
   - sle15/sp3
+schemaversion: 7.2
 image:
   name: SLES15-SP3-CHOST-BYOS
   specification: "SUSE Linux Enterprise Server 15 SP3 BYOS guest image optimized as container host"

--- a/images/cross-cloud/sles/chost/15-sp4/image.yaml
+++ b/images/cross-cloud/sles/chost/15-sp4/image.yaml
@@ -3,6 +3,7 @@ include-paths:
   - sle15/sp2
   - sle15/sp3
   - sle15/sp4
+schemaversion: 7.2
 image:
   name: SLES15-SP4-CHOST-BYOS
   specification: "SUSE Linux Enterprise Server 15 SP4 BYOS guest image optimized as container host"

--- a/images/cross-cloud/sles/ec2-ecs/15-sp2/image.yaml
+++ b/images/cross-cloud/sles/ec2-ecs/15-sp2/image.yaml
@@ -1,6 +1,7 @@
 include-paths:
   - sle15/sp1
   - sle15/sp2
+schemaversion: 7.2
 image:
   name: SLES15-SP2-EC2-ECS-HVM
   specification: "SUSE Linux Enterprise Server 15 SP2 ECS guest image for Amazon EC2 with HVM"

--- a/images/cross-cloud/sles/ec2-ecs/15-sp3/image.yaml
+++ b/images/cross-cloud/sles/ec2-ecs/15-sp3/image.yaml
@@ -2,6 +2,7 @@ include-paths:
   - sle15/sp1
   - sle15/sp2
   - sle15/sp3
+schemaversion: 7.2
 image:
   name: SLES15-SP3-EC2-ECS-HVM
   specification: "SUSE Linux Enterprise Server 15 SP3 ECS guest image for Amazon EC2 with HVM"

--- a/images/cross-cloud/sles/ec2-ecs/15-sp4/image.yaml
+++ b/images/cross-cloud/sles/ec2-ecs/15-sp4/image.yaml
@@ -3,6 +3,7 @@ include-paths:
   - sle15/sp2
   - sle15/sp3
   - sle15/sp4
+schemaversion: 7.2
 image:
   name: SLES15-SP4-EC2-ECS-HVM
   specification: "SUSE Linux Enterprise Server 15 SP4 ECS guest image for Amazon EC2 with HVM"

--- a/images/cross-cloud/sles/ondemand/15-sp2/image.yaml
+++ b/images/cross-cloud/sles/ondemand/15-sp2/image.yaml
@@ -1,6 +1,7 @@
 include-paths:
   - sle15/sp1
   - sle15/sp2
+schemaversion: 7.2
 image:
   name: SLES15-SP2
   specification: "SUSE Linux Enterprise Server 15 SP2 guest image"

--- a/images/cross-cloud/sles/ondemand/15-sp3/image.yaml
+++ b/images/cross-cloud/sles/ondemand/15-sp3/image.yaml
@@ -2,6 +2,7 @@ include-paths:
   - sle15/sp1
   - sle15/sp2
   - sle15/sp3
+schemaversion: 7.2
 image:
   name: SLES15-SP3
   specification: "SUSE Linux Enterprise Server 15 SP3 guest image"

--- a/images/cross-cloud/sles/ondemand/15-sp4/image.yaml
+++ b/images/cross-cloud/sles/ondemand/15-sp4/image.yaml
@@ -3,6 +3,7 @@ include-paths:
   - sle15/sp2
   - sle15/sp3
   - sle15/sp4
+schemaversion: 7.2
 image:
   name: SLES15-SP4
   specification: "SUSE Linux Enterprise Server 15 SP4 guest image"

--- a/images/defaults.yaml
+++ b/images/defaults.yaml
@@ -1,4 +1,5 @@
 schema: vm
+schmaversion: 6.2
 image:
   author: Public Cloud Team
   contact: public-cloud-dev@susecloud.net

--- a/schemas/vm.kiwi.templ
+++ b/schemas/vm.kiwi.templ
@@ -13,7 +13,7 @@
 {%-   endfor %}
 {%- endif %}
 
-<image schemaversion="6.2" name="{{ data['image']['name']}}" displayname="{{ data['image']['name'] }}">
+<image schemaversion="{{ data['schemaversion'] }}" name="{{ data['image']['name']}}" displayname="{{ data['image']['name'] }}">
     <description type="system">
         <author>{{ data['image']['author'] }}</author>
         <contact>{{ data['image']['contact'] }}</contact>
@@ -59,7 +59,7 @@
     {%- endfor %}
     </users>
     {%- if not data['repositories'] %}
-    <repository type="rpm-md" >
+    <repository type="rpm-md">
         <source path='obsrepositories:/'/>
     </repository>
     {%- else %}


### PR DESCRIPTION
Make 'schemaversion' an image config option.
Set '6.2' as default 'schemaversion'.
Set 'schemaversion: 7.1' in images/cross-cloud/sles/chost/15-sp1.
Set 'schemaversion: 7.2' in all SLE15 SP2+ image definitions.

This implements the 'simple' approach as outlined in https://github.com/SUSE-Enceladus/keg-recipes/issues/75. As mentioned, it may be nicer to set the schema version where the requirement for a specific version is created, e.g. in `data/csp/sle15/sp2` which changes the boot config style to schema 7.2. This would also reduce duplication as `schemaversion` is now in every image definition that doesn't use the default. However, it would make things more complicated in keg so I went the easier route, for now anyway.