### PR TITLE
Remove CAP Tools module in SLES 15 SP4

### DIFF
--- a/data/base/sle-modules/sle15/packages.yaml
+++ b/data/base/sle-modules/sle15/packages.yaml
@@ -2,7 +2,6 @@ packages:
   bootstrap:
     sle-modules:
       - sle-module-basesystem-release
-      - sle-module-cap-tools-release
       - sle-module-containers-release
       - sle-module-desktop-applications-release
       - sle-module-development-tools-release
@@ -10,3 +9,5 @@ packages:
       - sle-module-public-cloud-release
       - sle-module-server-applications-release
       - sle-module-web-scripting-release
+    sle-module-cap-tools:
+      - sle-module-cap-tools-release

--- a/data/base/sle-modules/sle15/sp4/packages.yaml
+++ b/data/base/sle-modules/sle15/sp4/packages.yaml
@@ -1,0 +1,3 @@
+packages:
+  bootstrap:
+    sle-module-cap-tools: Null


### PR DESCRIPTION
Remove the package 'sle-module-cap-tools-release' from all
SLES 15 SP4 images as the CAP tools module was removed because
the product got canceled. (jsc#PM-2646)