### PR TITLE
Schema version related fixes

### DIFF
--- a/data/csp/azure-baremetal/sle15/sp3/profile.yaml
+++ b/data/csp/azure-baremetal/sle15/sp3/profile.yaml
@@ -1,0 +1,5 @@
+profile:
+  parameters:
+    bootloader: Null
+  bootloader:
+    name: grub2

--- a/data/csp/azure-baremetal/vli/sle15/sp3/profile.yaml
+++ b/data/csp/azure-baremetal/vli/sle15/sp3/profile.yaml
@@ -1,0 +1,5 @@
+profile:
+  parameters:
+    bootloader_console: Null
+  bootloader:
+    console: console

--- a/images/cross-cloud/suse-manager/proxy/4.1/image.yaml
+++ b/images/cross-cloud/suse-manager/proxy/4.1/image.yaml
@@ -1,6 +1,7 @@
 include-paths:
   - sle15/sp1
   - sle15/sp2
+schemaversion: 7.2
 image:
   name: SUSE-Manager-Proxy-BYOS
   specification: "SUSE Manager 4.1 Proxy BYOS guest image"

--- a/images/cross-cloud/suse-manager/proxy/4.2/image.yaml
+++ b/images/cross-cloud/suse-manager/proxy/4.2/image.yaml
@@ -2,6 +2,7 @@ include-paths:
   - sle15/sp1
   - sle15/sp2
   - sle15/sp3
+schemaversion: 7.2
 image:
   name: SUSE-Manager-Proxy-BYOS
   specification: "SUSE Manager 4.2 Proxy BYOS guest image"

--- a/images/cross-cloud/suse-manager/server/4.1/image.yaml
+++ b/images/cross-cloud/suse-manager/server/4.1/image.yaml
@@ -1,6 +1,7 @@
 include-paths:
   - sle15/sp1
   - sle15/sp2
+schemaversion: 7.2
 image:
   name: SUSE-Manager-Server-BYOS
   specification: "SUSE Manager 4.1 Server BYOS guest image"

--- a/images/cross-cloud/suse-manager/server/4.2/image.yaml
+++ b/images/cross-cloud/suse-manager/server/4.2/image.yaml
@@ -2,6 +2,7 @@ include-paths:
   - sle15/sp1
   - sle15/sp2
   - sle15/sp3
+schemaversion: 7.2
 image:
   name: SUSE-Manager-Server-BYOS
   specification: "SUSE Manager 4.1 Server BYOS guest image"

--- a/images/defaults.yaml
+++ b/images/defaults.yaml
@@ -1,5 +1,5 @@
 schema: vm
-schmaversion: 6.2
+schemaversion: 6.2
 image:
   author: Public Cloud Team
   contact: public-cloud-dev@susecloud.net


### PR DESCRIPTION
Fix typo in defaults.
Use schemaversion=7.2 in SUSE Manager image definitions.
Use 7.2 style bootloader config scheme in Azure Baremetal for SLE15 SP3+.