### PR TITLE
Include public-cloud-release packages in most images

### DIFF
--- a/data/base/sle-modules/sle12/packages.yaml
+++ b/data/base/sle-modules/sle12/packages.yaml
@@ -7,8 +7,6 @@ packages:
       - sle-module-containers-release-POOL
       - sle-module-legacy-release
       - sle-module-legacy-release-POOL
-      - sle-module-public-cloud-release
-      - sle-module-public-cloud-release-POOL
       - sle-module-toolchain-release
       - sle-module-toolchain-release-POOL
       - sle-module-web-scripting-release

--- a/data/base/sle-modules/sle15/packages.yaml
+++ b/data/base/sle-modules/sle15/packages.yaml
@@ -6,7 +6,6 @@ packages:
       - sle-module-desktop-applications-release
       - sle-module-development-tools-release
       - sle-module-legacy-release
-      - sle-module-public-cloud-release
       - sle-module-server-applications-release
       - sle-module-web-scripting-release
     sle-module-cap-tools:

--- a/data/base/sle/sle12/packages.yaml
+++ b/data/base/sle/sle12/packages.yaml
@@ -1,4 +1,8 @@
 packages:
+  bootstrap:
+    sle-module-public-cloud:
+      - sle-module-public-cloud-release
+      - sle-module-public-cloud-release-POOL
   image:
     sle-common:
       - aaa_base-extras

--- a/data/base/sle/sle15/packages.yaml
+++ b/data/base/sle/sle15/packages.yaml
@@ -1,4 +1,7 @@
 packages:
+  bootstrap:
+    sle-module-public-cloud:
+      - sle-module-public-cloud-release
   image:
     sle-common:
       - aaa_base-extras


### PR DESCRIPTION
Move sle-module-public-cloud-release packages to base/sle module. This includes it in all image descriptions except CHOST.