### PR TITLE
AHB support

### DIFF
--- a/data/csp/azure/addon/azure-tools/sle12/config.yaml
+++ b/data/csp/azure/addon/azure-tools/sle12/config.yaml
@@ -2,6 +2,7 @@ config:
   services:
     azure-tools-config:
       - cloud-netconfig.timer
+      - regionsrv-enabler-azure.timer
   sysconfig:
     azure-tools-sysconfig:
       - file: /etc/sysconfig/network/config

--- a/data/csp/azure/addon/azure-tools/sle15/config.yaml
+++ b/data/csp/azure/addon/azure-tools/sle15/config.yaml
@@ -2,6 +2,7 @@ config:
   services:
     azure-tools-config:
       - cloud-netconfig.timer
+      - regionsrv-enabler-azure.timer
   sysconfig:
     azure-tools-sysconfig:
       - file: /etc/sysconfig/network/config

--- a/data/csp/azure/sle12/packages.yaml
+++ b/data/csp/azure/sle12/packages.yaml
@@ -19,7 +19,8 @@ packages:
         arch: aarch64
     azure-registration:
       - cloud-regionsrv-client
-      - regionsrv-certs
+      - cloud-regionsrv-client-addon-azure
       - cloud-regionsrv-client-plugin-azure
+      - regionsrv-certs
       - regionServiceClientConfigAzure
       - regionServiceCertsAzure

--- a/data/csp/azure/sle15/packages.yaml
+++ b/data/csp/azure/sle15/packages.yaml
@@ -14,8 +14,9 @@ packages:
         arch: x86_64
     azure-registration:
       - cloud-regionsrv-client
-      - regionsrv-certs
+      - cloud-regionsrv-client-addon-azure
       - cloud-regionsrv-client-plugin-azure
+      - regionsrv-certs
       - regionServiceClientConfigAzure
       - regionServiceCertsAzure
     bootloader-shim: Null

--- a/data/csp/ec2/sle12/packages.yaml
+++ b/data/csp/ec2/sle12/packages.yaml
@@ -11,7 +11,7 @@ packages:
         arch: x86_64
     ec2-registration:
       - cloud-regionsrv-client
-      - regionsrv-certs
       - cloud-regionsrv-client-plugin-ec2
+      - regionsrv-certs
       - regionServiceClientConfigEC2
       - regionServiceCertsEC2

--- a/data/csp/ec2/sle15/packages.yaml
+++ b/data/csp/ec2/sle15/packages.yaml
@@ -11,7 +11,7 @@ packages:
         arch: x86_64
     ec2-registration:
       - cloud-regionsrv-client
-      - regionsrv-certs
       - cloud-regionsrv-client-plugin-ec2
+      - regionsrv-certs
       - regionServiceClientConfigEC2
       - regionServiceCertsEC2

--- a/data/csp/gce/sle12/packages.yaml
+++ b/data/csp/gce/sle12/packages.yaml
@@ -11,7 +11,7 @@ packages:
       - kernel-default
     gce-registration:
       - cloud-regionsrv-client
-      - regionsrv-certs
       - cloud-regionsrv-client-plugin-gce
+      - regionsrv-certs
       - regionServiceClientConfigGCE
       - regionServiceCertsGCE

--- a/data/csp/gce/sle15/packages.yaml
+++ b/data/csp/gce/sle15/packages.yaml
@@ -13,7 +13,7 @@ packages:
       - patch
     gce-registration:
       - cloud-regionsrv-client
-      - regionsrv-certs
       - cloud-regionsrv-client-plugin-gce
+      - regionsrv-certs
       - regionServiceClientConfigGCE
       - regionServiceCertsGCE


### PR DESCRIPTION
Include cloud-regionsrv-client-addon-azure to support AHB

Preserve alphaorder in seubsection for registration packages