### PR TITLE
Add machine tag to SLE 15 EC2 definitions

### DIFF
--- a/data/csp/ec2/sle15/profile.yaml
+++ b/data/csp/ec2/sle15/profile.yaml
@@ -7,3 +7,5 @@ profile:
       multipath: "off"
       nvme_core.admin_timeout: 4294967295
       nvme_core.io_timeout: 4294967295
+  machine:
+    xen_loader: hvmloader

--- a/schemas/macros.jinja
+++ b/schemas/macros.jinja
@@ -35,6 +35,9 @@
               {%- endfor %}
             </oemconfig>
             {%- endif %}
+            {%- if profile['machine'] %}
+            <machine {%- for key, val in profile['machine'].items() %} {{ key }}="{{ val }}" {%- endfor -%}/>
+            {%- endif %}
         </type>
 {%- endmacro -%}
 {% macro print_packages(profile, content, multibuild) -%}


### PR DESCRIPTION
This adds the missing machine section to the SLE 15 EC2 image definitions. The jinja template should probably handle parameters like that a bit more generically in the long run.