### PR TITLE
Memory accounting for cgroups has changed again in 15 SP4, we no longer

### DIFF
--- a/data/kernel-options/cgroup-memory/sle15/sp4/profile.yaml
+++ b/data/kernel-options/cgroup-memory/sle15/sp4/profile.yaml
@@ -1,5 +1,4 @@
 profile:
   parameters:
     kernelcmdline:
-      cgroup_enable: memory
-      swapaccount: 1
+      cgroup.memory: Null

--- a/data/kernel-options/cgroup-memory/sle15/sp4/profile.yaml
+++ b/data/kernel-options/cgroup-memory/sle15/sp4/profile.yaml
@@ -1,0 +1,5 @@
+profile:
+  parameters:
+    kernelcmdline:
+      cgroup_enable: memory
+      swapaccount: 1


### PR DESCRIPTION
need the kmem switch.
  + There are no more separate sets of slabs for each memcgs (for accounting
  purposes), that now bring the memory overhead of separately cached percpu
  pages. Instead objects from all memcgs share the same set of slabs so what's
  accounted is the actual kernel usage and not this overhead. So the overhead
  should be lower than before we switched from SLAB to SLUB, and thus if
  "nokmem" was not needed in older SLAB kernels then it should not be
  needed also in 15SP4