### PR TITLE
Increase dhclient timeout to 300s

### DIFF
--- a/data/csp/azure/sle12/config.yaml
+++ b/data/csp/azure/sle12/config.yaml
@@ -1,6 +1,7 @@
 config:
   scripts:
     azure-config:
+      - dhclient-increase-timeout
       - set-password-policy
       - ssh-enable-keep-alive
       - sudo-disable-targetpw

--- a/data/csp/azure/sle15/config.yaml
+++ b/data/csp/azure/sle15/config.yaml
@@ -1,6 +1,7 @@
 config:
   scripts:
     azure-config:
+      - dhclient-increase-timeout
       - set-password-policy
       - ssh-enable-keep-alive
       - ssh-disable-challenge-response-auth

--- a/data/scripts/dhclient-increase-timeout.sh
+++ b/data/scripts/dhclient-increase-timeout.sh
@@ -1,0 +1,6 @@
+dc=/etc/dhclient.conf
+if grep -qE '^timeout' $dc ; then
+    sed -r -i 's/^timeout.*/timeout 300;/' $dc
+else
+    echo 'timeout 300;' >> $dc
+fi


### PR DESCRIPTION
Increase default dhclient timeout to 300s. Virtual NICs in Azure instances
may be nonfunctional for up to several minutes, potentially exceeding the
default 60s timeout. cloud-init uses dhclient to retrieve an initial IP
address.