### PR TITLE
Enable aarch64 build for SLES CHOST 15 SP1+ (issue#98)

### DIFF
--- a/images/cross-cloud/sles/chost/obs-archs.yaml
+++ b/images/cross-cloud/sles/chost/obs-archs.yaml
@@ -1,0 +1,2 @@
+image-config-comments:
+  obs-archs: "OBS-ExclusiveArch: x86_64 aarch64"


### PR DESCRIPTION
This fixes https://github.com/SUSE-Enceladus/keg-recipes/issues/98.