### PR TITLE
Move registration packages into add-on modules

### DIFF
--- a/data/base/common/sle12/packages.yaml
+++ b/data/base/common/sle12/packages.yaml
@@ -33,7 +33,6 @@ packages:
       - suse-build-key
       - SUSEConnect
       - systemd
-      - tar
       - tcpdump
       - timezone
       - udev

--- a/data/base/common/sle15/packages.yaml
+++ b/data/base/common/sle15/packages.yaml
@@ -24,7 +24,6 @@ packages:
       - system-group-wheel
       - system-user-nobody
       - systemd
-      - tar
       - tcpdump
       - terminfo
       - timezone

--- a/data/csp/azure/addon/azure-tools/sle12/packages.yaml
+++ b/data/csp/azure/addon/azure-tools/sle12/packages.yaml
@@ -5,3 +5,10 @@ packages:
       - cloud-netconfig-azure
       - lsscsi
       - python3-azuremetadata
+    azure-registration:
+      - cloud-regionsrv-client
+      - cloud-regionsrv-client-addon-azure
+      - cloud-regionsrv-client-plugin-azure
+      - regionsrv-certs
+      - regionServiceClientConfigAzure
+      - regionServiceCertsAzure

--- a/data/csp/azure/addon/azure-tools/sle15/packages.yaml
+++ b/data/csp/azure/addon/azure-tools/sle15/packages.yaml
@@ -5,3 +5,10 @@ packages:
       - cloud-netconfig-azure
       - lsscsi
       - python3-azuremetadata
+    azure-registration:
+      - cloud-regionsrv-client
+      - cloud-regionsrv-client-addon-azure
+      - cloud-regionsrv-client-plugin-azure
+      - regionsrv-certs
+      - regionServiceClientConfigAzure
+      - regionServiceCertsAzure

--- a/data/csp/azure/sle12/packages.yaml
+++ b/data/csp/azure/sle12/packages.yaml
@@ -17,10 +17,3 @@ packages:
         arch: x86_64
       - name: grub2-arm64-efi
         arch: aarch64
-    azure-registration:
-      - cloud-regionsrv-client
-      - cloud-regionsrv-client-addon-azure
-      - cloud-regionsrv-client-plugin-azure
-      - regionsrv-certs
-      - regionServiceClientConfigAzure
-      - regionServiceCertsAzure

--- a/data/csp/azure/sle15/packages.yaml
+++ b/data/csp/azure/sle15/packages.yaml
@@ -12,11 +12,4 @@ packages:
     azure-kernel:
       - name: kernel-default
         arch: x86_64
-    azure-registration:
-      - cloud-regionsrv-client
-      - cloud-regionsrv-client-addon-azure
-      - cloud-regionsrv-client-plugin-azure
-      - regionsrv-certs
-      - regionServiceClientConfigAzure
-      - regionServiceCertsAzure
     bootloader-shim: Null

--- a/data/csp/ec2/addon/aws-tools/sle12/packages.yaml
+++ b/data/csp/ec2/addon/aws-tools/sle12/packages.yaml
@@ -9,3 +9,9 @@ packages:
       - python-ec2deprecateimg
       - python-ec2publishimg
       - python-ec2uploadimg
+    ec2-registration:
+      - cloud-regionsrv-client
+      - cloud-regionsrv-client-plugin-ec2
+      - regionsrv-certs
+      - regionServiceClientConfigEC2
+      - regionServiceCertsEC2

--- a/data/csp/ec2/addon/aws-tools/sle15/packages.yaml
+++ b/data/csp/ec2/addon/aws-tools/sle15/packages.yaml
@@ -11,3 +11,9 @@ packages:
       - python3-ec2deprecateimg
       - python3-ec2publishimg
       - python3-ec2uploadimg
+    ec2-registration:
+      - cloud-regionsrv-client
+      - cloud-regionsrv-client-plugin-ec2
+      - regionsrv-certs
+      - regionServiceClientConfigEC2
+      - regionServiceCertsEC2

--- a/data/csp/ec2/sle12/packages.yaml
+++ b/data/csp/ec2/sle12/packages.yaml
@@ -9,9 +9,3 @@ packages:
         arch: x86_64
       - name: xen-tools-domU
         arch: x86_64
-    ec2-registration:
-      - cloud-regionsrv-client
-      - cloud-regionsrv-client-plugin-ec2
-      - regionsrv-certs
-      - regionServiceClientConfigEC2
-      - regionServiceCertsEC2

--- a/data/csp/ec2/sle15/packages.yaml
+++ b/data/csp/ec2/sle15/packages.yaml
@@ -9,9 +9,3 @@ packages:
         arch: x86_64
       - name: xen-tools-domU
         arch: x86_64
-    ec2-registration:
-      - cloud-regionsrv-client
-      - cloud-regionsrv-client-plugin-ec2
-      - regionsrv-certs
-      - regionServiceClientConfigEC2
-      - regionServiceCertsEC2

--- a/data/csp/gce/addon/gce-tools/sle12/packages.yaml
+++ b/data/csp/gce/addon/gce-tools/sle12/packages.yaml
@@ -3,3 +3,9 @@ packages:
     gce-tools:
       - cloud-netconfig-gce
       - python3-gcemetadata
+    gce-registration:
+      - cloud-regionsrv-client
+      - cloud-regionsrv-client-plugin-gce
+      - regionsrv-certs
+      - regionServiceClientConfigGCE
+      - regionServiceCertsGCE

--- a/data/csp/gce/addon/gce-tools/sle15/packages.yaml
+++ b/data/csp/gce/addon/gce-tools/sle15/packages.yaml
@@ -3,3 +3,9 @@ packages:
     gce-tools:
       - cloud-netconfig-gce
       - python3-gcemetadata
+    gce-registration:
+      - cloud-regionsrv-client
+      - cloud-regionsrv-client-plugin-gce
+      - regionsrv-certs
+      - regionServiceClientConfigGCE
+      - regionServiceCertsGCE

--- a/data/csp/gce/sle12/packages.yaml
+++ b/data/csp/gce/sle12/packages.yaml
@@ -9,9 +9,3 @@ packages:
       - growpart-rootgrow
       - grub2-x86_64-efi
       - kernel-default
-    gce-registration:
-      - cloud-regionsrv-client
-      - cloud-regionsrv-client-plugin-gce
-      - regionsrv-certs
-      - regionServiceClientConfigGCE
-      - regionServiceCertsGCE

--- a/data/csp/gce/sle15/packages.yaml
+++ b/data/csp/gce/sle15/packages.yaml
@@ -11,9 +11,3 @@ packages:
     gce-patch:
       # bsc#1165960
       - patch
-    gce-registration:
-      - cloud-regionsrv-client
-      - cloud-regionsrv-client-plugin-gce
-      - regionsrv-certs
-      - regionServiceClientConfigGCE
-      - regionServiceCertsGCE


### PR DESCRIPTION
This addresses https://github.com/SUSE-Enceladus/keg-recipes/issues/99. The tools add-on is used by basically all image definitions except for CHOST ones.

This also drop `tar` as an explicit inlcude.