### PR TITLE
add image definitions for SLES SAPCAL 15 SP3 and SP4

### DIFF
--- a/data/products/sapcal/sle15/packages.yaml
+++ b/data/products/sapcal/sle15/packages.yaml
@@ -41,7 +41,8 @@ packages:
       - rpm-build
       - samba
       - samba-client
-      - samba-client-32bit
+      - name: samba-client-32bit
+        arch: x86_64
       - sapconf
       - sysstat
       - tack

--- a/data/products/sapcal/sle15/sp3/packages.yaml
+++ b/data/products/sapcal/sle15/sp3/packages.yaml
@@ -1,0 +1,23 @@
+packages:
+  image:
+    sapcal-addon-x86:
+      - name: glibc-locale-32bit
+        arch: x86_64
+      - name: libcurl4-32bit
+        arch: x86_64
+      - name: libidn11-32bit
+        arch: x86_64
+      - name: libnghttp2-14-32bit
+        arch: x86_64
+      - name: libpsl5-32bit
+        arch: x86_64
+      - name: libssh4-32bit
+        arch: x86_64
+      - name: libuuid1-32bit
+        arch: x86_64
+      - name: libodbc2
+        arch: x86_64
+      - name: libopenssl1_0_0
+        arch: x86_64
+      - name: unixODBC
+        arch: x86_64

--- a/images/cross-cloud/sles/sapcal/15-sp3/image.yaml
+++ b/images/cross-cloud/sles/sapcal/15-sp3/image.yaml
@@ -1,0 +1,8 @@
+include-paths:
+  - sle15/sp1
+  - sle15/sp2
+  - sle15/sp3
+image:
+  name: SLES15-SP3-SAPCAL
+  specification: "SUSE Linux Enterprise Server 15 SP3 BYOS guest image for SAP Cloud Application Library"
+  version: 1.0.0

--- a/images/cross-cloud/sles/sapcal/15-sp4/image.yaml
+++ b/images/cross-cloud/sles/sapcal/15-sp4/image.yaml
@@ -1,0 +1,9 @@
+include-paths:
+  - sle15/sp1
+  - sle15/sp2
+  - sle15/sp3
+  - sle15/sp4
+image:
+  name: SLES15-SP4-SAPCAL
+  specification: "SUSE Linux Enterprise Server 15 SP4 BYOS guest image for SAP Cloud Application Library"
+  version: 1.0.0


### PR DESCRIPTION
This adds image definitions for SLES SAPCAL 15 SP3 and SP4. I've created an SP3 test build and compared the images to the released versions. There are a couple of differences between them. Most are changes that have been discussed and agreed on in conjunction with other images, like fixing small inconsistencies (like adding `azure-cli`), getting rid of obsolete stuff (like `/etc/securetty` entry). There are a couple of differences that may need discussion though:

- zypper-lifecycle-plugin (all flavors)

This is included in every image (except CHOST) in `keg-recipes`. It's not in the released SLES SAPCAL 15 SP3 version, but I think it should be.

- rpm-ndb (all flavors)

The description for the released image does not include `rpm-ndb` directly and lacks the related OBS comment. It does not make a difference in the binary image though because the OBS project is set up to switch `rpm` out for `rpm-ndb`. I assume this was just an oversight and the explicit `rpm-ndb` setting should be included in SAPCAL as well.

- /etc/chrony.d/ec2.conf (EC2)

This is missing in the released image but I don't see a reason why it should be excluded.