### PR TITLE
move Azure cloud register switch into own module

### DIFF
--- a/data/csp/azure/addon/azure-tools/sle12/config.yaml
+++ b/data/csp/azure/addon/azure-tools/sle12/config.yaml
@@ -2,7 +2,6 @@ config:
   services:
     azure-tools-config:
       - cloud-netconfig.timer
-      - regionsrv-enabler-azure.timer
   sysconfig:
     azure-tools-sysconfig:
       - file: /etc/sysconfig/network/config

--- a/data/csp/azure/addon/azure-tools/sle12/packages.yaml
+++ b/data/csp/azure/addon/azure-tools/sle12/packages.yaml
@@ -7,7 +7,6 @@ packages:
       - python3-azuremetadata
     azure-registration:
       - cloud-regionsrv-client
-      - cloud-regionsrv-client-addon-azure
       - cloud-regionsrv-client-plugin-azure
       - regionsrv-certs
       - regionServiceClientConfigAzure

--- a/data/csp/azure/addon/azure-tools/sle15/config.yaml
+++ b/data/csp/azure/addon/azure-tools/sle15/config.yaml
@@ -2,7 +2,6 @@ config:
   services:
     azure-tools-config:
       - cloud-netconfig.timer
-      - regionsrv-enabler-azure.timer
   sysconfig:
     azure-tools-sysconfig:
       - file: /etc/sysconfig/network/config

--- a/data/csp/azure/addon/azure-tools/sle15/packages.yaml
+++ b/data/csp/azure/addon/azure-tools/sle15/packages.yaml
@@ -7,7 +7,6 @@ packages:
       - python3-azuremetadata
     azure-registration:
       - cloud-regionsrv-client
-      - cloud-regionsrv-client-addon-azure
       - cloud-regionsrv-client-plugin-azure
       - regionsrv-certs
       - regionServiceClientConfigAzure

--- a/data/csp/azure/addon/cloudreg-switch/sle12/packages.yaml
+++ b/data/csp/azure/addon/cloudreg-switch/sle12/packages.yaml
@@ -1,0 +1,4 @@
+packages:
+  image:
+    azure-addon-cloudreg:
+      - cloud-regionsrv-client-addon-azure

--- a/data/csp/azure/addon/cloudreg-switch/sle15/config.yaml
+++ b/data/csp/azure/addon/cloudreg-switch/sle15/config.yaml
@@ -1,0 +1,4 @@
+config:
+  services:
+    azure-addon-cloudreg:
+      - regionsrv-enabler-azure.timer

--- a/data/csp/azure/addon/cloudreg-switch/sle15/packages.yaml
+++ b/data/csp/azure/addon/cloudreg-switch/sle15/packages.yaml
@@ -1,0 +1,4 @@
+packages:
+  image:
+    azure-addon-cloudreg:
+      - cloud-regionsrv-client-addon-azure

--- a/images/cross-cloud/sle-hpc/byos/profiles.yaml
+++ b/images/cross-cloud/sle-hpc/byos/profiles.yaml
@@ -8,6 +8,7 @@ profiles:
     description: Azure configuration
     include:
       - csp/azure/addon/azure-tools
+      - csp/azure/addon/cloudreg-switch
       - csp/azure/addon/waagent-rdma
       - csp/azure/byos/hpc
   EC2:

--- a/images/cross-cloud/sle-hpc/ondemand/profiles.yaml
+++ b/images/cross-cloud/sle-hpc/ondemand/profiles.yaml
@@ -10,6 +10,7 @@ profiles:
     include:
       - csp/azure/addon/azure-kernel
       - csp/azure/addon/azure-tools
+      - csp/azure/addon/cloudreg-switch
       - csp/azure/addon/waagent-rdma
       - csp/azure/ondemand/hpc
   EC2:

--- a/images/cross-cloud/sles-sap/byos/profiles.yaml
+++ b/images/cross-cloud/sles-sap/byos/profiles.yaml
@@ -8,6 +8,7 @@ profiles:
     description: Azure configuration
     include:
       - csp/azure/addon/azure-tools
+      - csp/azure/addon/cloudreg-switch
       - csp/azure/byos/sap
   EC2:
     description: EC2 configuration

--- a/images/cross-cloud/sles-sap/ondemand/profiles.yaml
+++ b/images/cross-cloud/sles-sap/ondemand/profiles.yaml
@@ -8,6 +8,7 @@ profiles:
   Azure:
     include:
       - csp/azure/addon/azure-tools
+      - csp/azure/addon/cloudreg-switch
       - csp/azure/ondemand/sap
   EC2:
     include:

--- a/images/cross-cloud/sles/byos/profiles.yaml
+++ b/images/cross-cloud/sles/byos/profiles.yaml
@@ -8,6 +8,7 @@ profiles:
     description: Azure configuration
     include:
       - csp/azure/addon/azure-tools
+      - csp/azure/addon/cloudreg-switch
       - csp/azure/byos/sles
   EC2:
     description: EC2 configuration

--- a/images/cross-cloud/sles/ondemand/profiles.yaml
+++ b/images/cross-cloud/sles/ondemand/profiles.yaml
@@ -9,6 +9,7 @@ profiles:
     include:
       - csp/azure/addon/azure-kernel
       - csp/azure/addon/azure-tools
+      - csp/azure/addon/cloudreg-switch
       - csp/azure/ondemand
     Azure-Basic:
       description: Azure configuration

--- a/images/single-cloud/12-sp5/azure/profiles.yaml
+++ b/images/single-cloud/12-sp5/azure/profiles.yaml
@@ -8,6 +8,7 @@ profiles:
       - base/cloudreg
       - base/sle-modules
       - csp/azure/addon/azure-tools
+      - csp/azure/addon/cloudreg-switch
       - csp/azure/ondemand
     Basic-On-Demand:
       description: SLES Basic On-Demand image
@@ -37,6 +38,7 @@ profiles:
   Base-BYOS:
     include:
       - csp/azure/addon/azure-tools
+      - csp/azure/addon/cloudreg-switch
       - csp/azure/addon/default-kernel
     BYOS:
       description: SLES BYOS image

--- a/images/single-cloud/sle-hpc-azure/profiles.yaml
+++ b/images/single-cloud/sle-hpc-azure/profiles.yaml
@@ -4,6 +4,7 @@ profiles:
       - base/common
       - base/sle
       - csp/azure/addon/azure-tools
+      - csp/azure/addon/cloudreg-switch
       - csp/azure/addon/waagent-rdma
       - csp/azure/byos/hpc
       - products/hpc/byos

--- a/images/single-cloud/sles-azure-byos/profiles.yaml
+++ b/images/single-cloud/sles-azure-byos/profiles.yaml
@@ -4,5 +4,6 @@ profiles:
       - base/common
       - base/sle
       - csp/azure/addon/azure-tools
+      - csp/azure/addon/cloudreg-switch
       - csp/azure/byos/sles
       - products/sles/byos

--- a/images/single-cloud/sles-sap-azure-byos/profiles.yaml
+++ b/images/single-cloud/sles-sap-azure-byos/profiles.yaml
@@ -4,5 +4,6 @@ profiles:
       - base/common
       - base/sle
       - csp/azure/addon/azure-tools
+      - csp/azure/addon/cloudreg-switch
       - csp/azure/byos/sap
       - products/sap/byos

--- a/images/single-cloud/sles-sap-azure/profiles.yaml
+++ b/images/single-cloud/sles-sap-azure/profiles.yaml
@@ -6,5 +6,6 @@ profiles:
       - base/sle
       - base/sle-modules
       - csp/azure/addon/azure-tools
+      - csp/azure/addon/cloudreg-switch
       - csp/azure/ondemand/sap
       - products/sap/ondemand


### PR DESCRIPTION
Move Azure cloud register auto-switch functionality into separate module and enable it in all image definitions for Azure that have cloud register support and are available in both BYOS and PAYG variants.

This PR effectively removes this functionality from SUMA and SAPCAL images (it was not included in CHOST).