### PR TITLE
Add image hardening

### DIFF
--- a/data/base/hardened/sle15/sp3/config.yaml
+++ b/data/base/hardened/sle15/sp3/config.yaml
@@ -1,0 +1,4 @@
+config:
+  scripts:
+    hardened-config:
+      - cloud-remediation

--- a/data/base/hardened/sle15/sp3/packages.yaml
+++ b/data/base/hardened/sle15/sp3/packages.yaml
@@ -1,0 +1,25 @@
+packages:
+  image:
+    hardened:
+      - aide
+      - audit-audispd-plugins
+      - cloud-remediation
+      - firewalld-lang
+      - libfreebl3-hmac
+      - libopenscap25
+      - libpcsclite1
+      - librdkafka1
+      - libsoftokn3-hmac
+      - libxmlsec1-1
+      - libxmlsec1-openssl1
+      - opensc
+      - openscap
+      - openscap-utils
+      - pam_apparmor
+      - pam_pkcs11
+      - pcsc-ccid
+      - pcsc-lite
+      - pcsc-tools
+      - perl-pcsc
+      - scap-security-guide
+      - pcsc-lite

--- a/data/scripts/cloud-remediation.sh
+++ b/data/scripts/cloud-remediation.sh
@@ -1,0 +1,3 @@
+# Run the image hardening script and then remove the package after completion
+/usr/bin/bash -e /usr/bin/cloud-remediation.sh
+zypper --non-interactive rm cloud-remediation

--- a/images/cross-cloud/sles-sap/byos/hardened/15-sp3/image.yaml
+++ b/images/cross-cloud/sles-sap/byos/hardened/15-sp3/image.yaml
@@ -1,0 +1,9 @@
+include-paths:
+  - sle15/sp1
+  - sle15/sp2
+  - sle15/sp3
+schemaversion: 7.2
+image:
+  name: SLES15-SP3-SAP-BYOS-Hardened
+  specification: "SUSE Linux Enterprise Server for SAP Applications 15 SP3 BYOS guest image"
+  version: 0.9.1

--- a/images/cross-cloud/sles-sap/byos/hardened/profiles.yaml
+++ b/images/cross-cloud/sles-sap/byos/hardened/profiles.yaml
@@ -1,0 +1,7 @@
+profiles:
+  common:
+    include:
+      - base/common
+      - base/hardened
+      - base/sle
+      - products/sap/byos

--- a/images/cross-cloud/sles-sap/ondemand/hardened/15-sp3/image.yaml
+++ b/images/cross-cloud/sles-sap/ondemand/hardened/15-sp3/image.yaml
@@ -1,0 +1,9 @@
+include-paths:
+  - sle15/sp1
+  - sle15/sp2
+  - sle15/sp3
+schemaversion: 7.2
+image:
+  name: SLES15-SP3-SAP-Hardened
+  specification: "SUSE Linux Enterprise Server for SAP Applications 15 SP3 guest image"
+  version: 0.9.1

--- a/images/cross-cloud/sles-sap/ondemand/hardened/profiles.yaml
+++ b/images/cross-cloud/sles-sap/ondemand/hardened/profiles.yaml
@@ -1,0 +1,8 @@
+profiles:
+  common:
+    include:
+      - base/common
+      - base/hardened
+      - base/sle
+      - base/sle-modules
+      - products/sap/ondemand

--- a/images/cross-cloud/sles/byos/hardened/15-sp3/image.yaml
+++ b/images/cross-cloud/sles/byos/hardened/15-sp3/image.yaml
@@ -1,0 +1,9 @@
+include-paths:
+  - sle15/sp1
+  - sle15/sp2
+  - sle15/sp3
+schemaversion: 7.2
+image:
+  name: SLES15-SP3-BYOS-Hardened
+  specification: "SUSE Linux Enterprise Server 15 SP3 BYOS guest image"
+  version: 0.9.1

--- a/images/cross-cloud/sles/byos/hardened/profiles.yaml
+++ b/images/cross-cloud/sles/byos/hardened/profiles.yaml
@@ -1,0 +1,7 @@
+profiles:
+  common:
+    include:
+      - base/common
+      - base/hardened
+      - base/sle
+      - products/sles/byos

--- a/images/cross-cloud/sles/ondemand/hardened/15-sp3/image.yaml
+++ b/images/cross-cloud/sles/ondemand/hardened/15-sp3/image.yaml
@@ -1,0 +1,9 @@
+include-paths:
+  - sle15/sp1
+  - sle15/sp2
+  - sle15/sp3
+schemaversion: 7.2
+image:
+  name: SLES15-SP3-Hardened
+  specification: "SUSE Linux Enterprise Server 15 SP3 guest image"
+  version: 0.9.1

--- a/images/cross-cloud/sles/ondemand/hardened/profiles.yaml
+++ b/images/cross-cloud/sles/ondemand/hardened/profiles.yaml
@@ -1,0 +1,8 @@
+profiles:
+  common:
+    include:
+      - base/common
+      - base/hardened
+      - base/sle-modules
+      - base/sle
+      - products/sles


### PR DESCRIPTION
This PR adds image definitions to provide "hardened" images for SLES 15 SP3 and SLES-15-SP3-SAP.  These also apply to SLES 15 SP4.   The hardened images contain packages required for the remediation to be run.  

In addition, both the script that performs the remediation and the corresponding invocation of the script have been added.

A new config script section `apply-pcs-hardening.sh` and the corresponding overlay have been added.

