### PR TITLE
Lock plymouth packages

### DIFF
--- a/data/base/common/leap15/config.yaml
+++ b/data/base/common/leap15/config.yaml
@@ -25,6 +25,13 @@ config:
           CONSOLE_ENCODING="UTF-8"
           CONSOLE_FONT="lat9w-16.psfu"
           CONSOLE_SCREENMAP="trivial"
+      - path: /etc/zypp/locks
+        append: True
+        content: |-
+          type: package
+          match_type: glob
+          case_sensitive: on
+          solvable_name: plymouth*
   services:
     common-services:
       - boot.device-mapper

--- a/data/base/common/sle12/sp5/config.yaml
+++ b/data/base/common/sle12/sp5/config.yaml
@@ -7,6 +7,13 @@ config:
           # yast in Public Cloud images fix
           NCURSES_NO_UTF8_ACS=1
           export NCURSES_NO_UTF8_ACS
+      - path: /etc/zypp/locks
+        append: True
+        content: |-
+          type: package
+          match_type: glob
+          case_sensitive: on
+          solvable_name: plymouth*
 setup:
   scripts:
     remove-dbus-machine-id:

--- a/data/base/common/sle15/config.yaml
+++ b/data/base/common/sle15/config.yaml
@@ -20,6 +20,13 @@ config:
           CONSOLE_ENCODING="UTF-8"
           CONSOLE_FONT="lat9w-16.psfu"
           CONSOLE_SCREENMAP="trivial"
+      - path: /etc/zypp/locks
+        append: True
+        content: |-
+          type: package
+          match_type: glob
+          case_sensitive: on
+          solvable_name: plymouth*
   services:
     common-services:
       - boot.device-mapper


### PR DESCRIPTION
+ Add a zypper lock to block the installation of plymouth packages.
  plymouth handled graphical boot screen display and is not desired
  in cloud images. Additionally it messes with the console setup (bsc#1195579)