### PR TITLE
use 0.9.0 as default image version

### DIFF
--- a/images/cross-cloud/sle-hpc/byos/15-sp2/image.yaml
+++ b/images/cross-cloud/sle-hpc/byos/15-sp2/image.yaml
@@ -5,6 +5,5 @@ schemaversion: 7.2
 image:
   name: SLES15-SP2-HPC-BYOS
   specification: "SUSE Linux Enterprise HPC 15 SP2 guest image"
-  version: 1.0.42
 profiles:
   GCE: Null

--- a/images/cross-cloud/sle-hpc/byos/15-sp3/image.yaml
+++ b/images/cross-cloud/sle-hpc/byos/15-sp3/image.yaml
@@ -6,4 +6,3 @@ schemaversion: 7.2
 image:
   name: SLES15-SP3-HPC-BYOS
   specification: "SUSE Linux Enterprise HPC 15 SP3 guest image"
-  version: 0.9.1

--- a/images/cross-cloud/sle-hpc/byos/15-sp4/image.yaml
+++ b/images/cross-cloud/sle-hpc/byos/15-sp4/image.yaml
@@ -7,4 +7,3 @@ schemaversion: 7.2
 image:
   name: SLES15-SP4-HPC-BYOS
   specification: "SUSE Linux Enterprise HPC 15 SP4 guest image"
-  version: 0.9.1

--- a/images/cross-cloud/sle-hpc/ondemand/15-sp2/image.yaml
+++ b/images/cross-cloud/sle-hpc/ondemand/15-sp2/image.yaml
@@ -5,6 +5,5 @@ schemaversion: 7.2
 image:
   name: SLES15-SP2-HPC
   specification: "SUSE Linux Enterprise HPC 15 SP2 guest image"
-  version: 1.0.42
 profiles:
   GCE: Null

--- a/images/cross-cloud/sle-hpc/ondemand/15-sp3/image.yaml
+++ b/images/cross-cloud/sle-hpc/ondemand/15-sp3/image.yaml
@@ -6,4 +6,3 @@ schemaversion: 7.2
 image:
   name: SLES15-SP3-HPC
   specification: "SUSE Linux Enterprise HPC 15 SP3 guest image"
-  version: 0.9.1

--- a/images/cross-cloud/sle-hpc/ondemand/15-sp4/image.yaml
+++ b/images/cross-cloud/sle-hpc/ondemand/15-sp4/image.yaml
@@ -7,4 +7,3 @@ schemaversion: 7.2
 image:
   name: SLES15-SP4-HPC
   specification: "SUSE Linux Enterprise HPC 15 SP4 guest image"
-  version: 0.9.1

--- a/images/cross-cloud/sles-sap/azure-li/12-sp4/image.yaml
+++ b/images/cross-cloud/sles-sap/azure-li/12-sp4/image.yaml
@@ -4,4 +4,3 @@ include-paths:
 image:
   name: SLES12-SP4-SAP-Azure-LI-BYOS
   specification: "SUSE Linux Enterprise Server for SAP Applications 12 SP4 Azure LI BYOS guest image"
-  version: 1.0.42

--- a/images/cross-cloud/sles-sap/azure-li/12-sp5/image.yaml
+++ b/images/cross-cloud/sles-sap/azure-li/12-sp5/image.yaml
@@ -5,4 +5,3 @@ include-paths:
 image:
   name: SLES12-SP5-SAP-Azure-LI-BYOS
   specification: "SUSE Linux Enterprise Server for SAP Applications 12 SP5 Azure LI BYOS guest image"
-  version: 1.0.42

--- a/images/cross-cloud/sles-sap/azure-li/15-sp1/image.yaml
+++ b/images/cross-cloud/sles-sap/azure-li/15-sp1/image.yaml
@@ -3,4 +3,3 @@ include-paths:
 image:
   name: SLES15-SP1-SAP-Azure-LI-BYOS
   specification: "SUSE Linux Enterprise Server for SAP Applications 15 SP1 Azure LI BYOS guest image"
-  version: 1.0.42

--- a/images/cross-cloud/sles-sap/azure-li/15-sp2/image.yaml
+++ b/images/cross-cloud/sles-sap/azure-li/15-sp2/image.yaml
@@ -5,4 +5,3 @@ schemaversion: 6.2
 image:
   name: SLES15-SP2-SAP-Azure-LI-BYOS
   specification: "SUSE Linux Enterprise Server for SAP Applications 15 SP2 Azure LI BYOS guest image"
-  version: 1.0.42

--- a/images/cross-cloud/sles-sap/azure-li/15-sp3/image.yaml
+++ b/images/cross-cloud/sles-sap/azure-li/15-sp3/image.yaml
@@ -6,4 +6,3 @@ schemaversion: 7.2
 image:
   name: SLES15-SP3-SAP-Azure-LI-BYOS
   specification: "SUSE Linux Enterprise Server for SAP Applications 15 SP3 Azure LI BYOS guest image"
-  version: 0.9.1

--- a/images/cross-cloud/sles-sap/azure-li/15-sp4/image.yaml
+++ b/images/cross-cloud/sles-sap/azure-li/15-sp4/image.yaml
@@ -7,4 +7,3 @@ schemaversion: 7.2
 image:
   name: SLES15-SP4-SAP-Azure-LI-BYOS
   specification: "SUSE Linux Enterprise Server for SAP Applications 15 SP4 Azure LI BYOS guest image"
-  version: 0.9.1

--- a/images/cross-cloud/sles-sap/azure-li/15/image.yaml
+++ b/images/cross-cloud/sles-sap/azure-li/15/image.yaml
@@ -3,4 +3,3 @@ include-paths:
 image:
   name: SLES15-SAP-Azure-LI-BYOS
   specification: "SUSE Linux Enterprise Server for SAP Applications 15 Azure LI BYOS guest image"
-  version: 1.0.42

--- a/images/cross-cloud/sles-sap/azure-vli/12-sp4/image.yaml
+++ b/images/cross-cloud/sles-sap/azure-vli/12-sp4/image.yaml
@@ -4,4 +4,3 @@ include-paths:
 image:
   name: SLES12-SP4-SAP-Azure-VLI-BYOS
   specification: "SUSE Linux Enterprise Server for SAP Applications 12 SP4 Azure VLI BYOS guest image"
-  version: 1.0.42

--- a/images/cross-cloud/sles-sap/azure-vli/12-sp5/image.yaml
+++ b/images/cross-cloud/sles-sap/azure-vli/12-sp5/image.yaml
@@ -5,4 +5,3 @@ include-paths:
 image:
   name: SLES12-SP5-SAP-Azure-VLI-BYOS
   specification: "SUSE Linux Enterprise Server for SAP Applications 12 SP5 Azure VLI BYOS guest image"
-  version: 1.0.42

--- a/images/cross-cloud/sles-sap/azure-vli/15-sp1/image.yaml
+++ b/images/cross-cloud/sles-sap/azure-vli/15-sp1/image.yaml
@@ -3,4 +3,3 @@ include-paths:
 image:
   name: SLES15-SP1-SAP-Azure-VLI-BYOS
   specification: "SUSE Linux Enterprise Server for SAP Applications 15 SP1 Azure VLI BYOS guest image"
-  version: 1.0.42

--- a/images/cross-cloud/sles-sap/azure-vli/15-sp2/image.yaml
+++ b/images/cross-cloud/sles-sap/azure-vli/15-sp2/image.yaml
@@ -5,4 +5,3 @@ schemaversion: 6.2
 image:
   name: SLES15-SP2-SAP-Azure-VLI-BYOS
   specification: "SUSE Linux Enterprise Server for SAP Applications 15 SP2 Azure VLI BYOS guest image"
-  version: 1.0.42

--- a/images/cross-cloud/sles-sap/azure-vli/15-sp3/image.yaml
+++ b/images/cross-cloud/sles-sap/azure-vli/15-sp3/image.yaml
@@ -6,4 +6,3 @@ schemaversion: 7.2
 image:
   name: SLES15-SP3-SAP-Azure-VLI-BYOS
   specification: "SUSE Linux Enterprise Server for SAP Applications 15 SP3 Azure VLI BYOS guest image"
-  version: 0.9.1

--- a/images/cross-cloud/sles-sap/azure-vli/15-sp4/image.yaml
+++ b/images/cross-cloud/sles-sap/azure-vli/15-sp4/image.yaml
@@ -7,4 +7,3 @@ schemaversion: 7.2
 image:
   name: SLES15-SP4-SAP-Azure-VLI-BYOS
   specification: "SUSE Linux Enterprise Server for SAP Applications 15 SP4 Azure VLI BYOS guest image"
-  version: 0.9.1

--- a/images/cross-cloud/sles-sap/azure-vli/15/image.yaml
+++ b/images/cross-cloud/sles-sap/azure-vli/15/image.yaml
@@ -3,4 +3,3 @@ include-paths:
 image:
   name: SLES15-SAP-Azure-VLI-BYOS
   specification: "SUSE Linux Enterprise Server for SAP Applications 15 Azure VLI BYOS guest image"
-  version: 1.0.42

--- a/images/cross-cloud/sles-sap/byos/15-sp2/image.yaml
+++ b/images/cross-cloud/sles-sap/byos/15-sp2/image.yaml
@@ -5,4 +5,3 @@ schemaversion: 7.2
 image:
   name: SLES15-SP2-SAP-BYOS
   specification: "SUSE Linux Enterprise Server for SAP Applications 15 SP2 BYOS guest image"
-  version: 1.0.42

--- a/images/cross-cloud/sles-sap/byos/15-sp3/image.yaml
+++ b/images/cross-cloud/sles-sap/byos/15-sp3/image.yaml
@@ -6,4 +6,3 @@ schemaversion: 7.2
 image:
   name: SLES15-SP3-SAP-BYOS
   specification: "SUSE Linux Enterprise Server for SAP Applications 15 SP3 BYOS guest image"
-  version: 0.9.1

--- a/images/cross-cloud/sles-sap/byos/15-sp4/image.yaml
+++ b/images/cross-cloud/sles-sap/byos/15-sp4/image.yaml
@@ -7,4 +7,3 @@ schemaversion: 7.2
 image:
   name: SLES15-SP4-SAP-BYOS
   specification: "SUSE Linux Enterprise Server for SAP Applications 15 SP4 BYOS guest image"
-  version: 0.9.1

--- a/images/cross-cloud/sles-sap/byos/hardened/15-sp3/image.yaml
+++ b/images/cross-cloud/sles-sap/byos/hardened/15-sp3/image.yaml
@@ -6,4 +6,3 @@ schemaversion: 7.2
 image:
   name: SLES15-SP3-SAP-BYOS-Hardened
   specification: "SUSE Linux Enterprise Server for SAP Applications 15 SP3 BYOS guest image"
-  version: 0.9.1

--- a/images/cross-cloud/sles-sap/ondemand/15-sp2/image.yaml
+++ b/images/cross-cloud/sles-sap/ondemand/15-sp2/image.yaml
@@ -5,4 +5,3 @@ schemaversion: 7.2
 image:
   name: SLES15-SP2-SAP
   specification: "SUSE Linux Enterprise Server for SAP Applications 15 SP2 guest image"
-  version: 1.0.42

--- a/images/cross-cloud/sles-sap/ondemand/15-sp3/image.yaml
+++ b/images/cross-cloud/sles-sap/ondemand/15-sp3/image.yaml
@@ -6,4 +6,3 @@ schemaversion: 7.2
 image:
   name: SLES15-SP3-SAP
   specification: "SUSE Linux Enterprise Server for SAP Applications 15 SP3 guest image"
-  version: 0.9.1

--- a/images/cross-cloud/sles-sap/ondemand/15-sp4/image.yaml
+++ b/images/cross-cloud/sles-sap/ondemand/15-sp4/image.yaml
@@ -7,4 +7,3 @@ schemaversion: 7.2
 image:
   name: SLES15-SP4-SAP
   specification: "SUSE Linux Enterprise Server for SAP Applications 15 SP4 guest image"
-  version: 0.9.1

--- a/images/cross-cloud/sles-sap/ondemand/hardened/15-sp3/image.yaml
+++ b/images/cross-cloud/sles-sap/ondemand/hardened/15-sp3/image.yaml
@@ -6,4 +6,3 @@ schemaversion: 7.2
 image:
   name: SLES15-SP3-SAP-Hardened
   specification: "SUSE Linux Enterprise Server for SAP Applications 15 SP3 guest image"
-  version: 0.9.1

--- a/images/cross-cloud/sles/byos/15-sp2/image.yaml
+++ b/images/cross-cloud/sles/byos/15-sp2/image.yaml
@@ -5,4 +5,3 @@ schemaversion: 7.2
 image:
   name: SLES15-SP2-BYOS
   specification: "SUSE Linux Enterprise Server 15 SP2 BYOS guest image"
-  version: 1.0.42

--- a/images/cross-cloud/sles/byos/15-sp3/image.yaml
+++ b/images/cross-cloud/sles/byos/15-sp3/image.yaml
@@ -6,4 +6,3 @@ schemaversion: 7.2
 image:
   name: SLES15-SP3-BYOS
   specification: "SUSE Linux Enterprise Server 15 SP3 BYOS guest image"
-  version: 0.9.1

--- a/images/cross-cloud/sles/byos/15-sp4/image.yaml
+++ b/images/cross-cloud/sles/byos/15-sp4/image.yaml
@@ -7,4 +7,3 @@ schemaversion: 7.2
 image:
   name: SLES15-SP4-BYOS
   specification: "SUSE Linux Enterprise Server 15 SP4 BYOS guest image"
-  version: 0.9.1

--- a/images/cross-cloud/sles/byos/hardened/15-sp3/image.yaml
+++ b/images/cross-cloud/sles/byos/hardened/15-sp3/image.yaml
@@ -6,4 +6,3 @@ schemaversion: 7.2
 image:
   name: SLES15-SP3-BYOS-Hardened
   specification: "SUSE Linux Enterprise Server 15 SP3 BYOS guest image"
-  version: 0.9.1

--- a/images/cross-cloud/sles/chost/15-sp1/image.yaml
+++ b/images/cross-cloud/sles/chost/15-sp1/image.yaml
@@ -4,7 +4,6 @@ schemaversion: 7.1
 image:
   name: SLES15-SP1-CHOST-BYOS
   specification: "SUSE Linux Enterprise Server 15 SP1 BYOS guest image optimized as container host"
-  version: 1.0.42
 profiles:
   Ali:
     description: Alibaba Cloud configuration

--- a/images/cross-cloud/sles/chost/15-sp2/image.yaml
+++ b/images/cross-cloud/sles/chost/15-sp2/image.yaml
@@ -5,4 +5,3 @@ schemaversion: 7.2
 image:
   name: SLES15-SP2-CHOST-BYOS
   specification: "SUSE Linux Enterprise Server 15 SP2 BYOS guest image optimized as container host"
-  version: 1.0.42

--- a/images/cross-cloud/sles/chost/15-sp3/image.yaml
+++ b/images/cross-cloud/sles/chost/15-sp3/image.yaml
@@ -6,4 +6,3 @@ schemaversion: 7.2
 image:
   name: SLES15-SP3-CHOST-BYOS
   specification: "SUSE Linux Enterprise Server 15 SP3 BYOS guest image optimized as container host"
-  version: 0.9.1

--- a/images/cross-cloud/sles/chost/15-sp4/image.yaml
+++ b/images/cross-cloud/sles/chost/15-sp4/image.yaml
@@ -7,4 +7,3 @@ schemaversion: 7.2
 image:
   name: SLES15-SP4-CHOST-BYOS
   specification: "SUSE Linux Enterprise Server 15 SP4 BYOS guest image optimized as container host"
-  version: 0.9.1

--- a/images/cross-cloud/sles/ec2-ecs/15-sp2/image.yaml
+++ b/images/cross-cloud/sles/ec2-ecs/15-sp2/image.yaml
@@ -5,4 +5,3 @@ schemaversion: 7.2
 image:
   name: SLES15-SP2-EC2-ECS-HVM
   specification: "SUSE Linux Enterprise Server 15 SP2 ECS guest image for Amazon EC2 with HVM"
-  version: 1.0.42

--- a/images/cross-cloud/sles/ec2-ecs/15-sp3/image.yaml
+++ b/images/cross-cloud/sles/ec2-ecs/15-sp3/image.yaml
@@ -6,4 +6,3 @@ schemaversion: 7.2
 image:
   name: SLES15-SP3-EC2-ECS-HVM
   specification: "SUSE Linux Enterprise Server 15 SP3 ECS guest image for Amazon EC2 with HVM"
-  version: 0.9.1

--- a/images/cross-cloud/sles/ec2-ecs/15-sp4/image.yaml
+++ b/images/cross-cloud/sles/ec2-ecs/15-sp4/image.yaml
@@ -7,4 +7,3 @@ schemaversion: 7.2
 image:
   name: SLES15-SP4-EC2-ECS-HVM
   specification: "SUSE Linux Enterprise Server 15 SP4 ECS guest image for Amazon EC2 with HVM"
-  version: 0.9.1

--- a/images/cross-cloud/sles/ondemand/15-sp2/image.yaml
+++ b/images/cross-cloud/sles/ondemand/15-sp2/image.yaml
@@ -5,4 +5,3 @@ schemaversion: 7.2
 image:
   name: SLES15-SP2
   specification: "SUSE Linux Enterprise Server 15 SP2 guest image"
-  version: 1.0.42

--- a/images/cross-cloud/sles/ondemand/15-sp3/image.yaml
+++ b/images/cross-cloud/sles/ondemand/15-sp3/image.yaml
@@ -6,4 +6,3 @@ schemaversion: 7.2
 image:
   name: SLES15-SP3
   specification: "SUSE Linux Enterprise Server 15 SP3 guest image"
-  version: 0.9.1

--- a/images/cross-cloud/sles/ondemand/15-sp4/image.yaml
+++ b/images/cross-cloud/sles/ondemand/15-sp4/image.yaml
@@ -7,4 +7,3 @@ schemaversion: 7.2
 image:
   name: SLES15-SP4
   specification: "SUSE Linux Enterprise Server 15 SP4 guest image"
-  version: 0.9.1

--- a/images/cross-cloud/sles/ondemand/hardened/15-sp3/image.yaml
+++ b/images/cross-cloud/sles/ondemand/hardened/15-sp3/image.yaml
@@ -6,4 +6,3 @@ schemaversion: 7.2
 image:
   name: SLES15-SP3-Hardened
   specification: "SUSE Linux Enterprise Server 15 SP3 guest image"
-  version: 0.9.1

--- a/images/cross-cloud/sles/sapcal/15-sp1/image.yaml
+++ b/images/cross-cloud/sles/sapcal/15-sp1/image.yaml
@@ -3,4 +3,3 @@ include-paths:
 image:
   name: SLES15-SP1-SAPCAL
   specification: "SUSE Linux Enterprise Server 15 SP1 BYOS guest image for SAP Cloud Application Library"
-  version: 1.0.42

--- a/images/cross-cloud/sles/sapcal/15-sp3/image.yaml
+++ b/images/cross-cloud/sles/sapcal/15-sp3/image.yaml
@@ -5,4 +5,3 @@ include-paths:
 image:
   name: SLES15-SP3-SAPCAL
   specification: "SUSE Linux Enterprise Server 15 SP3 BYOS guest image for SAP Cloud Application Library"
-  version: 1.0.0

--- a/images/cross-cloud/sles/sapcal/15-sp4/image.yaml
+++ b/images/cross-cloud/sles/sapcal/15-sp4/image.yaml
@@ -6,4 +6,3 @@ include-paths:
 image:
   name: SLES15-SP4-SAPCAL
   specification: "SUSE Linux Enterprise Server 15 SP4 BYOS guest image for SAP Cloud Application Library"
-  version: 1.0.0

--- a/images/cross-cloud/suse-manager/server/4.1/image.yaml
+++ b/images/cross-cloud/suse-manager/server/4.1/image.yaml
@@ -5,6 +5,6 @@ schemaversion: 7.2
 image:
   name: SUSE-Manager-4-1-Server-BYOS
   specification: "SUSE Manager 4.1 Server BYOS guest image"
-  version: 4.1.42
+  version: 4.1.0
 repositories:
   - path: obsrepositories:/

--- a/images/defaults.yaml
+++ b/images/defaults.yaml
@@ -3,6 +3,7 @@ schemaversion: 6.2
 image:
   author: Public Cloud Team
   contact: public-cloud-dev@susecloud.net
+  version: 0.9.0
 users:
   - name: root
     groups:

--- a/images/single-cloud/12-sp5/azure/image.yaml
+++ b/images/single-cloud/12-sp5/azure/image.yaml
@@ -5,4 +5,3 @@ include-paths:
 image:
   name: SLES12-SP5-Azure
   specification: "SUSE Linux Enterprise Server 12 Service Pack 5 guest image for Microsoft Azure"
-  version: 1.0.42

--- a/images/single-cloud/12-sp5/ec2/image.yaml
+++ b/images/single-cloud/12-sp5/ec2/image.yaml
@@ -5,4 +5,3 @@ include-paths:
 image:
   name: SLES12-SP5-EC2
   specification: "SUSE Linux Enterprise Server 12 Service Pack 5 guest image for Amazon EC2"
-  version: 1.0.42

--- a/images/single-cloud/12-sp5/gce/image.yaml
+++ b/images/single-cloud/12-sp5/gce/image.yaml
@@ -5,4 +5,3 @@ include-paths:
 image:
   name: SLES12-SP5-GCE
   specification: "SUSE Linux Enterprise Server 12 Service Pack 5 guest image for Google Compute Engine"
-  version: 1.0.42

--- a/images/single-cloud/sle-hpc-azure/15-sp1/image.yaml
+++ b/images/single-cloud/sle-hpc-azure/15-sp1/image.yaml
@@ -3,4 +3,3 @@ include-paths:
 image:
   name: SLES15-SP1-Azure-HPC-BYOS
   specification: "SUSE Linux Enterprise HPC 15 SP1 guest image for Microsoft Azure"
-  version: 1.0.42

--- a/images/single-cloud/sle-hpc-ec2/15-sp1/image.yaml
+++ b/images/single-cloud/sle-hpc-ec2/15-sp1/image.yaml
@@ -3,4 +3,3 @@ include-paths:
 image:
   name: SLES15-SP1-EC2-HPC-BYOS
   specification: "SUSE Linux Enterprise HPC 15 SP1 guest image for Amazon EC2"
-  version: 1.0.42

--- a/images/single-cloud/sles-azure-byos/15-sp1/image.yaml
+++ b/images/single-cloud/sles-azure-byos/15-sp1/image.yaml
@@ -3,4 +3,3 @@ include-paths:
 image:
   name: SLES15-SP1-Azure-BYOS
   specification: "SUSE Linux Enterprise Server 15 SP1 BYOS guest image for Microsoft Azure BYOS configuration"
-  version: 1.0.42

--- a/images/single-cloud/sles-azure-byos/15/image.yaml
+++ b/images/single-cloud/sles-azure-byos/15/image.yaml
@@ -3,4 +3,3 @@ include-paths:
 image:
   name: SLES15-Azure-BYOS
   specification: "SUSE Linux Enterprise Server 15 BYOS guest image for Microsoft Azure BYOS configuration"
-  version: 1.0.42

--- a/images/single-cloud/sles-ec2-byos/15-sp1/image.yaml
+++ b/images/single-cloud/sles-ec2-byos/15-sp1/image.yaml
@@ -3,4 +3,3 @@ include-paths:
 image:
   name: SLES15-SP1-EC2-BYOS
   specification: "SUSE Linux Enterprise Server 15 SP1 BYOS guest image for Amazon EC2"
-  version: 1.0.42

--- a/images/single-cloud/sles-ec2-byos/15/image.yaml
+++ b/images/single-cloud/sles-ec2-byos/15/image.yaml
@@ -3,4 +3,3 @@ include-paths:
 image:
   name: SLES15-EC2-BYOS
   specification: "SUSE Linux Enterprise Server 15 BYOS guest image for Amazon EC2"
-  version: 1.0.42

--- a/images/single-cloud/sles-ec2-chost-byos/15/image.yaml
+++ b/images/single-cloud/sles-ec2-chost-byos/15/image.yaml
@@ -3,4 +3,3 @@ include-paths:
 image:
   name: SLES15-EC2-CHOST-HVM-BYOS
   specification: "SUSE Linux Enterprise Server 15 BYOS guest image optimized as container host"
-  version: 1.0.42

--- a/images/single-cloud/sles-gce-byos/15-sp1/image.yaml
+++ b/images/single-cloud/sles-gce-byos/15-sp1/image.yaml
@@ -3,4 +3,3 @@ include-paths:
 image:
   name: SLES15-SP1-GCE-BYOS
   specification: "SUSE Linux Enterprise Server 15 SP1 BYOS guest image for Google Compute Engine"
-  version: 1.0.42

--- a/images/single-cloud/sles-gce-byos/15/image.yaml
+++ b/images/single-cloud/sles-gce-byos/15/image.yaml
@@ -3,4 +3,3 @@ include-paths:
 image:
   name: SLES15-GCE-BYOS
   specification: "SUSE Linux Enterprise Server 15 BYOS guest image for Google Compute Engine"
-  version: 1.0.42

--- a/images/single-cloud/sles-sap-azure-byos/15-sp1/image.yaml
+++ b/images/single-cloud/sles-sap-azure-byos/15-sp1/image.yaml
@@ -3,4 +3,3 @@ include-paths:
 image:
   name: SLES15-SP1-SAP-Azure-BYOS
   specification: "SUSE Linux Enterprise Server for SAP Applications 15 SP1 BYOS guest image for Microsoft Azure BYOS configuration"
-  version: 1.0.42

--- a/images/single-cloud/sles-sap-azure-byos/15/image.yaml
+++ b/images/single-cloud/sles-sap-azure-byos/15/image.yaml
@@ -3,4 +3,3 @@ include-paths:
 image:
   name: SLES15-SAP-Azure-BYOS
   specification: "SUSE Linux Enterprise Server for SAP Applications 15 BYOS guest image for Microsoft Azure BYOS configuration"
-  version: 1.0.42

--- a/images/single-cloud/sles-sap-azure/15-sp1/image.yaml
+++ b/images/single-cloud/sles-sap-azure/15-sp1/image.yaml
@@ -3,4 +3,3 @@ include-paths:
 image:
   name: SLES15-SP1-SAP-Azure
   specification: "SUSE Linux Enterprise Server for SAP Applications 15 SP1 guest image for Microsoft Azure"
-  version: 1.0.42

--- a/images/single-cloud/sles-sap-azure/15/image.yaml
+++ b/images/single-cloud/sles-sap-azure/15/image.yaml
@@ -3,4 +3,3 @@ include-paths:
 image:
   name: SLES15-SAP-Azure
   specification: "SUSE Linux Enterprise Server for SAP Applications 15 guest image for Microsoft Azure"
-  version: 1.0.42

--- a/images/single-cloud/sles-sap-ec2-byos/15-sp1/image.yaml
+++ b/images/single-cloud/sles-sap-ec2-byos/15-sp1/image.yaml
@@ -3,4 +3,3 @@ include-paths:
 image:
   name: SLES15-SP1-SAP-EC2-BYOS
   specification: "SUSE Linux Enterprise Server for SAP Applications 15 SP1 BYOS guest image for Amazon EC2 BYOS configuration"
-  version: 1.0.42

--- a/images/single-cloud/sles-sap-ec2-byos/15/image.yaml
+++ b/images/single-cloud/sles-sap-ec2-byos/15/image.yaml
@@ -3,4 +3,3 @@ include-paths:
 image:
   name: SLES15-SAP-EC2-BYOS
   specification: "SUSE Linux Enterprise Server for SAP Applications 15 BYOS guest image for Amazon EC2 BYOS configuration"
-  version: 1.0.42

--- a/images/single-cloud/sles-sap-ec2/15-sp1/image.yaml
+++ b/images/single-cloud/sles-sap-ec2/15-sp1/image.yaml
@@ -3,4 +3,3 @@ include-paths:
 image:
   name: SLES15-SP1-SAP-EC2
   specification: "SUSE Linux Enterprise Server for SAP Applications 15 SP1 BYOS guest image for Amazon EC2"
-  version: 1.0.42

--- a/images/single-cloud/sles-sap-ec2/15/image.yaml
+++ b/images/single-cloud/sles-sap-ec2/15/image.yaml
@@ -3,4 +3,3 @@ include-paths:
 image:
   name: SLES15-SAP-EC2
   specification: "SUSE Linux Enterprise Server for SAP Applications 15 BYOS guest image for Amazon EC2"
-  version: 1.0.42

--- a/images/single-cloud/sles-sap-gce-byos/15-sp1/image.yaml
+++ b/images/single-cloud/sles-sap-gce-byos/15-sp1/image.yaml
@@ -3,4 +3,3 @@ include-paths:
 image:
   name: SLES15-SP1-SAP-GCE-BYOS
   specification: "SUSE Linux Enterprise Server for SAP Applications 15 SP1 BYOS guest image for Google Compute Engine BYOS configuration"
-  version: 1.0.42

--- a/images/single-cloud/sles-sap-gce-byos/15/image.yaml
+++ b/images/single-cloud/sles-sap-gce-byos/15/image.yaml
@@ -3,4 +3,3 @@ include-paths:
 image:
   name: SLES15-SAP-GCE-BYOS
   specification: "SUSE Linux Enterprise Server for SAP Applications 15 BYOS guest image for Google Compute Engine BYOS configuration"
-  version: 1.0.42

--- a/images/single-cloud/sles-sap-gce/15-sp1/image.yaml
+++ b/images/single-cloud/sles-sap-gce/15-sp1/image.yaml
@@ -3,4 +3,3 @@ include-paths:
 image:
   name: SLES15-SP1-SAP-GCE
   specification: "SUSE Linux Enterprise Server for SAP Applications 15 SP1 BYOS guest image for Google Compute Engine"
-  version: 1.0.42

--- a/images/single-cloud/sles-sap-gce/15/image.yaml
+++ b/images/single-cloud/sles-sap-gce/15/image.yaml
@@ -3,4 +3,3 @@ include-paths:
 image:
   name: SLES15-SAP-GCE
   specification: "SUSE Linux Enterprise Server for SAP Applications 15 BYOS guest image for Google Compute Engine"
-  version: 1.0.42


### PR DESCRIPTION
This removes image version from all individual image definitions except for SUSE Manager and adds `0.9.0` as default version. Since the image version will auto-incremented in the build system, the image version in keg just serves as an initial version setting, so having a global default makes more sense.