### PR TITLE
add dracut-resume overlay module

### DIFF
--- a/data/csp/ec2/sle15/overlayfiles.yaml
+++ b/data/csp/ec2/sle15/overlayfiles.yaml
@@ -6,6 +6,7 @@ overlayfiles:
       - cloud-cfg-disable-network-config
       - dracut-aws-type-switch
       - dracut-ext4
+      - dracut-resume
       - dracut-xfs
       - modprobe-nvme-options
       - udev-nvme-timeout

--- a/data/overlayfiles/dracut-resume/etc/dracut.conf.d/11-resume.conf
+++ b/data/overlayfiles/dracut-resume/etc/dracut.conf.d/11-resume.conf
@@ -1,0 +1,1 @@
+add_dracutmodules+=" resume "


### PR DESCRIPTION
This adds an overlay module that enables the dracut `resume` module and adds it to all SLE 15 EC2 image definitions.

Is this required in other definitions too? Is hibernation supported in SLE 12 or in other frameworks?