### PR TITLE
Add HA repos to SLES For SAP by default

### DIFF
--- a/data/products/sap/ondemand/sle15/packages.yaml
+++ b/data/products/sap/ondemand/sle15/packages.yaml
@@ -1,6 +1,5 @@
 packages:
   bootstrap:
     sles4sap-ondemand:
-      - sle-ha-release
       - sle-module-live-patching-release
       - sle-module-sap-applications-release

--- a/data/products/sap/sle15/packages.yaml
+++ b/data/products/sap/sle15/packages.yaml
@@ -51,3 +51,4 @@ packages:
   bootstrap:
     sap-release:
       - SLES_SAP-release
+      - sle-ha-release


### PR DESCRIPTION
+ Both on-demand and BYOS instances should automatically register the HA
  repos. Per request of the SAP team bsc#1197398