### PR TITLE
SLES 15 SP4 has a Python 3 module instead of a Python 2 module

### DIFF
--- a/data/base/sle-modules/sle15/sp1/packages.yaml
+++ b/data/base/sle-modules/sle15/sp1/packages.yaml
@@ -1,4 +1,4 @@
 packages:
   bootstrap:
-    sle-module-python2:
+    sle-module-python:
       - sle-module-python2-release

--- a/data/base/sle-modules/sle15/sp4/packages.yaml
+++ b/data/base/sle-modules/sle15/sp4/packages.yaml
@@ -1,3 +1,5 @@
 packages:
   bootstrap:
     sle-module-cap-tools: Null
+    sle-module-python:
+      - sle-module-python3-release


### PR DESCRIPTION
- Change the namespace for the Python module to be version independent and
  include the python3 module release package in 15 SP4 and later distros