### PR TITLE
Disable multiversion kernels

### DIFF
--- a/data/base/common/sle12/config.yaml
+++ b/data/base/common/sle12/config.yaml
@@ -6,6 +6,7 @@ config:
       - remove-root-pw
       - set-prodlink
       - zypp-disable-delta-rpms
+      - zypp-disable-multiver-kernel
   files:
     common-sysconfig-keyboard:
       - path: /etc/sysconfig/console

--- a/data/base/common/sle15/config.yaml
+++ b/data/base/common/sle15/config.yaml
@@ -6,6 +6,7 @@ config:
       - remove-root-pw
       - set-prodlink
       - zypp-disable-delta-rpms
+      - zypp-disable-multiver-kernel
   files:
     common-sysconfig:
       - path: /etc/profile

--- a/data/scripts/zypp-disable-multiver-kernel.sh
+++ b/data/scripts/zypp-disable-multiver-kernel.sh
@@ -1,0 +1,1 @@
+sed -i -e 's/latest,latest-1,running/latest,running/' /etc/zypp/zypp.conf


### PR DESCRIPTION
- By default the libzypp configuration shipped retains 1 past kernel version,
  i.e. this is a multiversion kernel setup. However for distribution migration
  multiple kernels do not make sense and are not supported. We should create
  images that are configured by default to support distribution migration.