### PR TITLE
SUSE Manager 4.3: drop obsolete dependencies

### DIFF
--- a/data/products/suse-manager/server/sle15/sp4/packages.yaml
+++ b/data/products/suse-manager/server/sle15/sp4/packages.yaml
@@ -1,0 +1,5 @@
+packages:
+  image:
+    manager-server-deps:
+      # avoid log4j12-mini
+      - log4j12


### PR DESCRIPTION
Drop obsolete antlr3-runtime and javamail from package list.
Drop unnecessary python3-numpy and python3-PyJWT from package list.