### PR TITLE
rename SUSE Manager images

### DIFF
--- a/images/cross-cloud/suse-manager/proxy/4.1/image.yaml
+++ b/images/cross-cloud/suse-manager/proxy/4.1/image.yaml
@@ -3,8 +3,8 @@ include-paths:
   - sle15/sp2
 schemaversion: 7.2
 image:
-  name: SUSE-Manager-4-1-Proxy-BYOS
-  specification: "SUSE Manager 4.1 Proxy BYOS guest image"
+  name: SLES15-SP2-Manager-Proxy-4-1-BYOS
+  specification: "SUSE Manager Proxy 4.1 BYOS guest image"
   version: 4.1.0
 repositories:
   - path: obsrepositories:/

--- a/images/cross-cloud/suse-manager/proxy/4.2/image.yaml
+++ b/images/cross-cloud/suse-manager/proxy/4.2/image.yaml
@@ -4,8 +4,8 @@ include-paths:
   - sle15/sp3
 schemaversion: 7.2
 image:
-  name: SUSE-Manager-4-2-Proxy-BYOS
-  specification: "SUSE Manager 4.2 Proxy BYOS guest image"
+  name: SLES15-SP3-Manager-Proxy-4-2-BYOS
+  specification: "SUSE Manager Proxy 4.2 BYOS guest image"
   version: 4.2.0
 repositories:
   - path: obsrepositories:/

--- a/images/cross-cloud/suse-manager/proxy/4.3/image.yaml
+++ b/images/cross-cloud/suse-manager/proxy/4.3/image.yaml
@@ -5,8 +5,8 @@ include-paths:
   - sle15/sp4
 schemaversion: 7.2
 image:
-  name: SUSE-Manager-4-3-Proxy-BYOS
-  specification: "SUSE Manager 4.3 Proxy BYOS guest image"
+  name: SLES15-SP4-Manager-Proxy-4-3-BYOS
+  specification: "SUSE Manager Proxy 4.3 BYOS guest image"
   version: 4.3.0
 repositories:
   - path: obsrepositories:/

--- a/images/cross-cloud/suse-manager/server/4.1/image.yaml
+++ b/images/cross-cloud/suse-manager/server/4.1/image.yaml
@@ -3,8 +3,8 @@ include-paths:
   - sle15/sp2
 schemaversion: 7.2
 image:
-  name: SUSE-Manager-4-1-Server-BYOS
-  specification: "SUSE Manager 4.1 Server BYOS guest image"
+  name: SLES15-SP2-Manager-Server-4-1-BYOS
+  specification: "SUSE Manager Server 4.1 BYOS guest image"
   version: 4.1.0
 repositories:
   - path: obsrepositories:/

--- a/images/cross-cloud/suse-manager/server/4.2/image.yaml
+++ b/images/cross-cloud/suse-manager/server/4.2/image.yaml
@@ -4,8 +4,8 @@ include-paths:
   - sle15/sp3
 schemaversion: 7.2
 image:
-  name: SUSE-Manager-4-2-Server-BYOS
-  specification: "SUSE Manager 4.2 Server BYOS guest image"
+  name: SLES15-SP3-Manager-Server-4-2-BYOS
+  specification: "SUSE Manager Server 4.2 BYOS guest image"
   version: 4.2.0
 repositories:
   - path: obsrepositories:/

--- a/images/cross-cloud/suse-manager/server/4.3/image.yaml
+++ b/images/cross-cloud/suse-manager/server/4.3/image.yaml
@@ -5,8 +5,8 @@ include-paths:
   - sle15/sp4
 schemaversion: 7.2
 image:
-  name: SUSE-Manager-4-3-Server-BYOS
-  specification: "SUSE Manager 4.3 Server BYOS guest image"
+  name: SLES15-SP4-Manager-Server-4-3-BYOS
+  specification: "SUSE Manager Server 4.3 BYOS guest image"
   version: 4.3.0
 repositories:
   - path: obsrepositories:/


### PR DESCRIPTION
Change SUSE Manager image name to include base SLES version.
Swap version and build type (i.e. server/proxy).