### PR TITLE
Explicitly include javamail in SUSE Manager Server 4.3

### DIFF
--- a/data/products/suse-manager/server/sle15/packages.yaml
+++ b/data/products/suse-manager/server/sle15/packages.yaml
@@ -14,7 +14,7 @@ packages:
       - release-notes-sles
     manager-server-deps:
       - antlr3-runtime
-      # direct inlcude to avoid picking classpathx-mail instead of
+      # direct include to avoid picking classpathx-mail instead of
       # javamail which does not work with spacewalk-java
       - javamail
       - log4j12

--- a/data/products/suse-manager/server/sle15/sp4/packages.yaml
+++ b/data/products/suse-manager/server/sle15/sp4/packages.yaml
@@ -3,3 +3,8 @@ packages:
     manager-server-deps:
       # avoid log4j12-mini
       - log4j12
+      # direct inlcude to avoid picking classpathx-mail instead of
+      # javamail which does not work with spacewalk-java
+      - javamail
+      # needed but is only recommend
+      - libtcnative-1-0

--- a/data/products/suse-manager/server/sle15/sp4/packages.yaml
+++ b/data/products/suse-manager/server/sle15/sp4/packages.yaml
@@ -3,7 +3,7 @@ packages:
     manager-server-deps:
       # avoid log4j12-mini
       - log4j12
-      # direct inlcude to avoid picking classpathx-mail instead of
+      # direct include to avoid picking classpathx-mail instead of
       # javamail which does not work with spacewalk-java
       - javamail
       # needed but is only recommend


### PR DESCRIPTION
Explicitly include `javamail` to avoid `classpathx-mail` (bsc#1202455). Also include `libtcnative-1-0`.