### PR TITLE
Include hostinfo and address iscsi config

### DIFF
--- a/data/base/common/sle12/config.yaml
+++ b/data/base/common/sle12/config.yaml
@@ -3,6 +3,7 @@ config:
     common-config:
       - generate-motd
       - polkit-set-default-privs
+      - remove-iscsi-config
       - remove-root-pw
       - set-prodlink
       - zypp-disable-delta-rpms

--- a/data/base/common/sle15/config.yaml
+++ b/data/base/common/sle15/config.yaml
@@ -3,6 +3,7 @@ config:
     common-config:
       - generate-motd
       - polkit-set-default-privs
+      - remove-iscsi-config
       - remove-root-pw
       - set-prodlink
       - zypp-disable-delta-rpms

--- a/data/base/sle/sle12/packages.yaml
+++ b/data/base/sle/sle12/packages.yaml
@@ -26,6 +26,7 @@ packages:
       - expect
       - fping
       - glibc-i18ndata
+      - hostinfo
       - icmpinfo
       - irqbalance
       - kdump

--- a/data/base/sle/sle15/packages.yaml
+++ b/data/base/sle/sle15/packages.yaml
@@ -28,6 +28,7 @@ packages:
       - fonts-config
       - fping
       - glibc-i18ndata
+      - hostinfo
       - iproute2
       - irqbalance
       - krb5-client

--- a/data/csp/ec2/settings/ecs/sle12/packages.yaml
+++ b/data/csp/ec2/settings/ecs/sle12/packages.yaml
@@ -7,6 +7,7 @@ packages:
       - crash
       - cronie
       - ethtool
+      - hostinfo
       - lockdev
       - mozilla-nss-certs
       - nscd

--- a/data/csp/ec2/settings/ecs/sle15/packages.yaml
+++ b/data/csp/ec2/settings/ecs/sle15/packages.yaml
@@ -8,6 +8,7 @@ packages:
       - cronie
       - docker-img-store-setup
       - ethtool
+      - hostinfo
       - iproute2
       - irqbalance
       - krb5-client

--- a/data/scripts/remove-iscsi-config.sh
+++ b/data/scripts/remove-iscsi-config.sh
@@ -1,0 +1,4 @@
+# Generation of the iscsi config file moved to %post of the package
+# This implies that all instances have the same iscsi initiator name as the
+# file is generated during image build. We do not want this (bsc#1202540)
+rm -rf /etc/iscsi/initiatorname.iscsi


### PR DESCRIPTION
- Include the hostinfo package in our images by default per AWS request
  (bsc#1199872). This also supports the expansion of information in motd
- Remove the iscsi initiator config that gets generated during package install
  to avoid the same initiator name on all instances. While the change was
  introduced in 15 SP4 there is no harm in having the remove in all image
  builds. Therefore this is included in the default setup for SLE 15 and
  SLE 12. (bsc#1202540)