### PR TITLE
Ignore 'rpm' (use rpm-ndb) also for single-cloud descriptions

### DIFF
--- a/images/single-cloud/obs-comments.yaml
+++ b/images/single-cloud/obs-comments.yaml
@@ -1,0 +1,2 @@
+image-config-comments:
+  obs-ignore-rpm: "OBS-IgnorePackage: rpm"


### PR DESCRIPTION
The comment `<!-- OBS-IgnorePackage: rpm -->` is not used for single-cloud image description and currently results in unresolvables, see https://build.suse.de/project/monitor/SUSE:SLE-15-SP5:GA:Staging:B?arch_x86_64=1&defaults=0&repo_images=1&unresolvable=1 for instance.