### PR TITLE
Remove duplicate haveged service entries

### DIFF
--- a/data/base/common/sle12/config.yaml
+++ b/data/base/common/sle12/config.yaml
@@ -26,6 +26,7 @@ config:
           solvable_name: plymouth*
   services:
     common-services:
+      - haveged
       - sshd
   sysconfig:
     common-sysconfig:

--- a/data/csp/ec2/sle12/config.yaml
+++ b/data/csp/ec2/sle12/config.yaml
@@ -17,7 +17,6 @@ config:
       - cloud-final
       - cloud-init
       - cloud-init-local
-      - haveged
     ec2-time-sync:
       - ntpd
     ec2-cloud-netconfig:

--- a/data/csp/gce/sle12/config.yaml
+++ b/data/csp/gce/sle12/config.yaml
@@ -33,7 +33,6 @@ config:
         value: "cloud-netconfig dns-resolver dns-bind dns-dnsmasq nis ntp-runtime"
   services:
     gce-services:
-      - haveged
       - ntpd
       - google-guest-agent
       - google-osconfig-agent

--- a/data/csp/openstack/sle15/config.yaml
+++ b/data/csp/openstack/sle15/config.yaml
@@ -4,8 +4,6 @@ config:
       - ssh-disable-challenge-response-auth
       - ssh-disable-password-login
   services:
-    vm-services:
-      - haveged
     openstack-cloud-init:
       - cloud-init-local
       - cloud-init

--- a/data/csp/sle12/defaults.yaml
+++ b/data/csp/sle12/defaults.yaml
@@ -2,7 +2,6 @@ config:
   services:
     vm-services:
       - chronyd
-      - haveged
 packages:
   _namespace_default_bootloader:
     package:

--- a/data/csp/sle15/defaults.yaml
+++ b/data/csp/sle15/defaults.yaml
@@ -2,7 +2,6 @@ config:
   services:
     vm-services:
       - chronyd
-      - haveged
 packages:
   _namespace_default_bootloader:
     package:


### PR DESCRIPTION
This removes the `haveged` entries from the services sections in the csp sub-modules. It was already enabled in `base/common/sle15` and this PR also adds it to `base/common/sle12`.

The existing Azure LI/VLI image descriptions do not enable `haveged` explicitly but it ends up enabled anyway per systemd preset. Since that means it's enabled everywhere I set it in `base/common` (though technically doesn't affect the image configuration unless the systemd preset is altered). If we actually do not want to have `haveged` enabled in Azure LI/VLI I can move it to the csp defaults and overwrite it with an explicit disable in `csp/azure-baremetal`. However, it's always been enabled, as said, and I think it still useful on a baremetal server that lacks user entropy.

Said that, https://github.com/jirka-h/haveged/blob/master/README.md states that a comparable implementation was added to kernel 5.4, so perhaps we want to simply remove `haveged` from SLE 15 SP4+ definitions.