### PR TITLE
Update SLE Micro image data

### DIFF
--- a/data/base/common/sle15/packages.yaml
+++ b/data/base/common/sle15/packages.yaml
@@ -26,7 +26,6 @@ packages:
       - udev
       - wget
       - which
-      - wicked
       - xfsprogs
   _namespace_common_rpm:
     package:

--- a/data/base/sle/sle15/packages.yaml
+++ b/data/base/sle/sle15/packages.yaml
@@ -61,6 +61,7 @@ packages:
       - tcsh
       - telnet
       - vim
+      - wicked
       - yast2
       - yast2-add-on
       - yast2-audit-laf

--- a/data/csp/azure/settings/micro/sle15/config.yaml
+++ b/data/csp/azure/settings/micro/sle15/config.yaml
@@ -3,6 +3,7 @@ config:
     azure-waagent: Null
     azure-default-kernel-log-level: Null
     azure-dhclient-timeout: Null
+    azure-sshd-config: Null
   services:
     azure-afterburn-checkin:
       - afterburn-checkin

--- a/data/csp/azure/settings/micro/sle15/overlayfiles.yaml
+++ b/data/csp/azure/settings/micro/sle15/overlayfiles.yaml
@@ -1,0 +1,3 @@
+archive:
+  _namespace_azure_cloud_init_cfg: Null
+  _namespace_azure_motd_waagent: Null

--- a/data/csp/azure/settings/micro/sle15/sp4/config.yaml
+++ b/data/csp/azure/settings/micro/sle15/sp4/config.yaml
@@ -1,0 +1,4 @@
+config:
+  services:
+    azure-regionsrv-timer:
+      - regionsrv-enabler-azure.timer

--- a/data/csp/azure/settings/micro/sle15/sp4/packages.yaml
+++ b/data/csp/azure/settings/micro/sle15/sp4/packages.yaml
@@ -1,0 +1,11 @@
+packages:
+  _namespace_azure_registration:
+    package:
+      - cloud-regionsrv-client
+      - cloud-regionsrv-client-plugin-azure
+      - regionsrv-certs
+      - regionServiceClientConfigAzure
+      - regionServiceCertsAzure
+  _namespace_azure_regionsrv_client_addon:
+    package:
+      - cloud-regionsrv-client-addon-azure

--- a/data/csp/azure/sle15/config.yaml
+++ b/data/csp/azure/sle15/config.yaml
@@ -3,11 +3,12 @@ config:
     azure-scripts:
       - set-password-policy
       - ssh-enable-keep-alive
-      - ssh-disable-challenge-response-auth
     azure-default-kernel-log-level:
       - keep-default-kernel-log-level
     azure-dhclient-timeout:
       - dhclient-increase-timeout
+    azure-sshd-config:
+      - ssh-disable-challenge-response-auth
     azure-waagent:
       - waagent-disable-auto-update
       - waagent-enable-all-ssh-host-key-types

--- a/data/csp/azure/sle15/overlayfiles.yaml
+++ b/data/csp/azure/sle15/overlayfiles.yaml
@@ -2,15 +2,19 @@ archive:
   _namespace_azure_base:
     _include_overlays:
       - chrony-azure-ptp
-      - cloud-cfg-azure
-      - cloud-cfg-disable-network-config
       - modprobe-blacklist-azure-vm
-      - motd-addon-waagent
       - udev-hyperv-ptp
       - udev-ioscheduler-none
+  _namespace_azure_cloud_init_cfg:
+    _include_overlays:
+      - cloud-cfg-azure
+      - cloud-cfg-disable-network-config
   _namespace_azure_emergency_shell:
     _include_overlays:
       - rescue-force-sulogin
+  _namespace_azure_motd_waagent:
+    _include_overlays:
+      - motd-addon-waagent
   _namespace_azure_sysconfig_network:
     _include_overlays:
       - sysconfig-network-cloud-netconfig

--- a/data/csp/ec2/settings/ecs/sle15/packages.yaml
+++ b/data/csp/ec2/settings/ecs/sle15/packages.yaml
@@ -29,6 +29,7 @@ packages:
       - tcpd
       - tcpdump
       - vim
+      - wicked
   _namespace_ec2_ecs_pubcloud_release:
     package:
       - sle-module-public-cloud-release

--- a/data/csp/ec2/settings/micro/sle15/sp4/packages.yaml
+++ b/data/csp/ec2/settings/micro/sle15/sp4/packages.yaml
@@ -1,0 +1,11 @@
+packages:
+  _namespace_ec2_registration:
+    package:
+      - cloud-regionsrv-client
+      - cloud-regionsrv-client-plugin-ec2
+      - regionsrv-certs
+      - regionServiceClientConfigEC2
+      - regionServiceCertsEC2
+  _namespace_ec2_imgutils:
+    package:
+      - python3-ec2imgutils

--- a/data/csp/gce/settings/micro/sle15/preferences.yaml
+++ b/data/csp/gce/settings/micro/sle15/preferences.yaml
@@ -4,6 +4,4 @@ preferences:
       bootpartsize: Null
       filesystem: btrfs
       kernelcmdline:
-        debug: []
         ignition.platform.id: gcp
-        rd.debug: []

--- a/data/csp/gce/settings/micro/sle15/sp4/packages.yaml
+++ b/data/csp/gce/settings/micro/sle15/sp4/packages.yaml
@@ -1,0 +1,8 @@
+packages:
+  _namespace_gce_registration:
+    package:
+      - cloud-regionsrv-client
+      - cloud-regionsrv-client-plugin-gce
+      - regionsrv-certs
+      - regionServiceClientConfigGCE
+      - regionServiceCertsGCE

--- a/data/products/chost/sle15/packages.yaml
+++ b/data/products/chost/sle15/packages.yaml
@@ -24,6 +24,7 @@ packages:
       - tcpdump
       - vim
       - vlan
+      - wicked
   _namespace_chost_btrfsprogs:
     package:
       - btrfsmaintenance

--- a/data/products/sle-micro/5.3/packages.yaml
+++ b/data/products/sle-micro/5.3/packages.yaml
@@ -1,0 +1,4 @@
+packages:
+  _namespace_sle_micro_network_mgmt:
+    package:
+      - NetworkManager

--- a/data/products/sle-micro/packages.yaml
+++ b/data/products/sle-micro/packages.yaml
@@ -12,7 +12,6 @@ packages:
       - cockpit-system
       - cockpit-ws
       - cockpit
-      - cockpit-wicked
       - conntrack-tools
       - container-selinux
       - cracklib-dict-small
@@ -45,3 +44,7 @@ packages:
       - vlan
       - yast2-logs
       - zypper-needs-restarting
+  _namespace_sle_micro_network_mgmt:
+    package:
+      - cockpit-wicked
+      - wicked

--- a/images/cross-cloud/sle-micro/byos/5.3/image.yaml
+++ b/images/cross-cloud/sle-micro/byos/5.3/image.yaml
@@ -3,6 +3,7 @@ include-paths:
   - sle15/sp2
   - sle15/sp3
   - sle15/sp4
+  - "5.3"
 image:
   _attributes:
     schemaversion: "7.2"

--- a/images/cross-cloud/sle-micro/byos/5.3/preferences.yaml
+++ b/images/cross-cloud/sle-micro/byos/5.3/preferences.yaml
@@ -1,0 +1,26 @@
+image:
+  preferences:
+    - _include: base/common
+    - _attributes:
+        profiles: [Azure]
+        arch: x86_64
+      _include:
+        - csp/azure/settings/micro
+        - products/sle-micro
+    - _attributes:
+        profiles: [Azure]
+        arch: aarch64
+      _include:
+        - csp/azure/settings/aarch64
+        - csp/azure/settings/micro
+        - products/sle-micro
+    - _attributes:
+        profiles: [EC2]
+      _include:
+        - csp/ec2/settings/micro
+        - products/sle-micro
+    - _attributes:
+        profiles: [GCE]
+      _include:
+        - csp/gce/settings/micro
+        - products/sle-micro


### PR DESCRIPTION
Mostly update for SLE Micro 5.3, with a couple of fixes for older version. This brings the SLE Micro 5.3 descriptions in line with the released versions with the following exceptions:

- obsolete klogd removed
- wording in /etc/motd differs slightly
- obsolete /etc/securetty entry dropped
- obsolete /etc/sysconfig/clock entries dropped
- cloud-netconfig enabled (released version only has it installed but not enabled)
- multiversion kernel disabled

Apart from that, I removed `debug` and `rd.debug` kernel parameters from all SLE Micro for GCE definitions. This was only in the released SLE Micro 5.1 for GCE and seems a bit like a left-over. Please let me know if it was included on purpose and I'll re-add it.