### PR TITLE
Add mozilla-nss-tools to SLE 15 hardened packages

### DIFF
--- a/data/base/sle/hardened/sle15/packages.yaml
+++ b/data/base/sle/hardened/sle15/packages.yaml
@@ -11,6 +11,7 @@ packages:
       - libsoftokn3-hmac
       - libxmlsec1-1
       - libxmlsec1-openssl1
+      - mozilla-nss-tools
       - opensc
       - openscap
       - openscap-utils


### PR DESCRIPTION
Package required, otherwise smart card cert rules validation fails.