### PR TITLE
Fix SLE Micro /etc/motd template (bsc#1204406)

### DIFF
--- a/data/overlayfiles/motd-sle-micro/etc/motd
+++ b/data/overlayfiles/motd-sle-micro/etc/motd
@@ -2,7 +2,6 @@
 {CAPTION}
 
 {INCLUDES}
-Activate the web console with: systemctl enable --now cockpit.socket
 
 Documentation: https://www.suse.com/documentation/sle-micro/{VERSION}
 Community: https://community.suse.com/


### PR DESCRIPTION
Remove web console activation notice from SLE Micro /etc/motd template which leads to a duplicate entry, as it gets added by the cockpit.socket unit.