### PR TITLE
Fix SUSE Manager image names

### DIFF
--- a/images/cross-cloud/suse-manager/server/4.3/image.yaml
+++ b/images/cross-cloud/suse-manager/server/4.3/image.yaml
@@ -6,7 +6,7 @@ include-paths:
 image:
   _attributes:
     schemaversion: "7.2"
-    name: SLES15-SP4-SUSE-Manager-Server-4-3-BYOS
-    displayname: SLES15-SP4-SUSE-Manager-Server-4-3-BYOS
+    name: SLES15-SP4-Manager-Server-4-3-BYOS
+    displayname: SLES15-SP4-Manager-Server-4-3-BYOS
   description:
     specification: "SUSE Manager Server 4.3 BYOS guest image"

--- a/images/cross-cloud/suse-manager/server/4.4/image.yaml
+++ b/images/cross-cloud/suse-manager/server/4.4/image.yaml
@@ -7,7 +7,7 @@ include-paths:
 image:
   _attributes:
     schemaversion: "7.2"
-    name: SLES15-SP5-SUSE-Manager-Server-4-4-BYOS
-    displayname: SLES15-SP5-SUSE-Manager-Server-4-4-BYOS
+    name: SLES15-SP5-Manager-Server-4-4-BYOS
+    displayname: SLES15-SP5-Manager-Server-4-4-BYOS
   description:
     specification: "SUSE Manager Server 4.4 BYOS guest image"


### PR DESCRIPTION
Drop 'SUSE' from Manager 4.3 and 4.4 image names.