### PR TITLE
Fix btrfs grub subvolumes for aarch64

### DIFF
--- a/data/products/sle-micro/aarch64/preferences.yaml
+++ b/data/products/sle-micro/aarch64/preferences.yaml
@@ -1,0 +1,8 @@
+preferences:
+  type:
+    systemdisk:
+      _namespace_micro_aarch64:
+        volume:
+          - _attributes:
+              name: boot/grub2/arm64-efi
+              mountpoint: boot/grub2/arm64-efi

--- a/data/products/sle-micro/preferences.yaml
+++ b/data/products/sle-micro/preferences.yaml
@@ -30,9 +30,6 @@ preferences:
         - _attributes:
             name: boot/grub2/i386-pc
         - _attributes:
-            name: boot/grub2/x86_64-efi
-            mountpoint: boot/grub2/x86_64-efi
-        - _attributes:
             name: boot/writable
         - _attributes:
             name: usr/local

--- a/data/products/sle-micro/x86_64/preferences.yaml
+++ b/data/products/sle-micro/x86_64/preferences.yaml
@@ -1,0 +1,8 @@
+preferences:
+  type:
+    systemdisk:
+      _namespace_micro_x86_64:
+        volume:
+          - _attributes:
+              name: boot/grub2/x86_64-efi
+              mountpoint: boot/grub2/x86_64-efi

--- a/images/cross-cloud/sle-micro/byos/5.3/preferences.yaml
+++ b/images/cross-cloud/sle-micro/byos/5.3/preferences.yaml
@@ -6,21 +6,35 @@ image:
         arch: x86_64
       _include:
         - csp/azure/settings/micro
-        - products/sle-micro
+        - products/sle-micro/x86_64
     - _attributes:
         profiles: [Azure]
         arch: aarch64
       _include:
         - csp/azure/settings/aarch64
         - csp/azure/settings/micro
-        - products/sle-micro
+        - products/sle-micro/aarch64
     - _attributes:
         profiles: [EC2]
+        arch: x86_64
       _include:
         - csp/ec2/settings/micro
-        - products/sle-micro
+        - products/sle-micro/x86_64
+    - _attributes:
+        profiles: [EC2]
+        arch: aarch64
+      _include:
+        - csp/ec2/settings/micro
+        - products/sle-micro/aarch64
     - _attributes:
         profiles: [GCE]
+        arch: x86_64
       _include:
         - csp/gce/settings/micro
-        - products/sle-micro
+        - products/sle-micro/x86_64
+    - _attributes:
+        profiles: [GCE]
+        arch: aarch64
+      _include:
+        - csp/gce/settings/micro
+        - products/sle-micro/aarch64


### PR DESCRIPTION
Add architecture specific profiles to all SLE Micro 5.3 flavors. Add architecture specific btrfs subvolumes for grub.