### PR TITLE
Include license tag in SLE HPC 15 SP4+ for GCE

### DIFF
--- a/images/cross-cloud/sle-hpc/byos/15-sp4/preferences.yaml
+++ b/images/cross-cloud/sle-hpc/byos/15-sp4/preferences.yaml
@@ -19,4 +19,5 @@ image:
         - csp/ec2/settings/hpc/byos
     - _attributes:
         profiles: [GCE]
-      _include: csp/gce/settings/hpc
+      _include:
+        - csp/gce/settings/hpc/byos

--- a/images/cross-cloud/sle-hpc/byos/15-sp5/preferences.yaml
+++ b/images/cross-cloud/sle-hpc/byos/15-sp5/preferences.yaml
@@ -19,4 +19,5 @@ image:
         - csp/ec2/settings/hpc/byos
     - _attributes:
         profiles: [GCE]
-      _include: csp/gce/settings/hpc
+      _include:
+        - csp/gce/settings/hpc/byos


### PR DESCRIPTION
Fix preferences include path in GCE profile so GCE license tags are included in SLE HPC BYOS 15 SP4+ image descriptions.