### PR TITLE
Move 'ed' to the generic sle15 packages.yaml to avoid namespace clashes

### DIFF
--- a/data/csp/azure-baremetal/sle15/packages.yaml
+++ b/data/csp/azure-baremetal/sle15/packages.yaml
@@ -33,6 +33,9 @@ packages:
       - libssh2-1
       - MozillaFirefox-branding-SLE
       - patterns-sap-hana
+      # 'ed' is needed as dependency of
+      # 'postfix' <- clamsap <- patterns-sap-hana (bsc#1205457)
+      - ed        
       - wireshark
   _namespace_azure_baremetal_addon_msft:
     package:

--- a/data/csp/azure-baremetal/sle15/sp5/packages.yaml
+++ b/data/csp/azure-baremetal/sle15/sp5/packages.yaml
@@ -1,4 +1,0 @@
-packages:
-  _namespace_azure_baremetal_hana_addon:
-    package:
-      - ed


### PR DESCRIPTION
When I added the package 'ed' in data/csp/azure-baremetal/sle15/sp5/packages.yaml I used the same namespace as in data/csp/azure-baremetal/sle15/packages.yaml which overwrote the latter, so packages were missing. After discussion this issue with Joe we agreed on creating the new namespace '_namespace_azure_baremetal_hana_addon_deps' to solve this issue.