### PR TITLE
Move rpm-ndb into bootstrap section (issue#178)

### DIFF
--- a/data/base/bootstrap/sle15/sp2/packages.yaml
+++ b/data/base/bootstrap/sle15/sp2/packages.yaml
@@ -1,0 +1,4 @@
+packages:
+ _namespace_rpm_ndb:
+   package:
+     - rpm-ndb

--- a/data/base/common/sle15/sp2/packages.yaml
+++ b/data/base/common/sle15/sp2/packages.yaml
@@ -1,4 +1,2 @@
 packages:
-  _namespace_common_rpm:
-    package:
-      - rpm-ndb
+  _namespace_common_rpm: Null


### PR DESCRIPTION
Move rpm-ndb into bootstrap section to prevent builds outside the build service from using plain rpm.

Fixes https://github.com/SUSE-Enceladus/keg-recipes/issues/178.