### PR TITLE
Remove unsupported packages

### DIFF
--- a/data/base/common/sle15/packages.yaml
+++ b/data/base/common/sle15/packages.yaml
@@ -12,7 +12,6 @@ packages:
       - kdump
       - openssh
       - parted
-      - rsyslog
       - sudo
       - supportutils
       - suse-build-key
@@ -24,7 +23,6 @@ packages:
       - terminfo
       - timezone
       - udev
-      - wget
       - which
       - xfsprogs
   _namespace_common_rpm:

--- a/data/base/sle/sle15/packages.yaml
+++ b/data/base/sle/sle15/packages.yaml
@@ -50,6 +50,7 @@ packages:
       - psmisc
       - quota
       - rsync
+      - rsyslog
       - screen
       - sle-module-public-cloud-release
       - strace
@@ -61,6 +62,7 @@ packages:
       - tcsh
       - telnet
       - vim
+      - wget
       - wicked
       - yast2
       - yast2-add-on
@@ -97,14 +99,12 @@ packages:
       - yast2-registration
       - yast2-samba-client
       - yast2-samba-server
-      - yast2-schema
       - yast2-security
       - yast2-squid
       - yast2-sudo
       - yast2-support
       - yast2-sysconfig
       - yast2-tftp-server
-      - yast2-trans-en_US
       - yast2-transfer
       - yast2-trans-stats
       - yast2-tune
@@ -115,3 +115,6 @@ packages:
       - yp-tools
       - zip
       - zsh
+  _namespace_sle_common_yast2_trans:
+    package:
+      - yast2-trans-en_US

--- a/data/base/sle/sle15/sp2/packages.yaml
+++ b/data/base/sle/sle15/sp2/packages.yaml
@@ -1,0 +1,2 @@
+packages:
+  _namespace_sle_common_yast2_trans: Null

--- a/data/csp/ec2/settings/ecs/sle15/packages.yaml
+++ b/data/csp/ec2/settings/ecs/sle15/packages.yaml
@@ -25,10 +25,12 @@ packages:
       - psmisc
       - quota
       - rsync
+      - rsyslog
       - supportutils-plugin-suse-public-cloud
       - tcpd
       - tcpdump
       - vim
+      - wget
       - wicked
   _namespace_ec2_ecs_pubcloud_release:
     package:

--- a/data/products/chost/sle15/packages.yaml
+++ b/data/products/chost/sle15/packages.yaml
@@ -18,12 +18,14 @@ packages:
       - nfs-client
       - open-iscsi
       - pciutils
+      - rsyslog
       - runc
       - socat
       - supportutils-plugin-suse-public-cloud
       - tcpdump
       - vim
       - vlan
+      - wget
       - wicked
   _namespace_chost_btrfsprogs:
     package:

--- a/data/products/hpc/sle15/packages.yaml
+++ b/data/products/hpc/sle15/packages.yaml
@@ -8,9 +8,6 @@ packages:
       - ibutils
       - libdat2-2
       - libibverbs1
-      - _attributes:
-          name: libibverbs1-32bit
-          arch: x86_64
       - librdmacm1
       - mpiP_3_4_1-gnu-mpich-hpc
       - mpich-gnu-hpc

--- a/data/products/sap/sle15/packages.yaml
+++ b/data/products/sap/sle15/packages.yaml
@@ -33,7 +33,6 @@ packages:
       - saptune
       - socat
       - supportutils-plugin-ha-sap
-      - system-role-sles4sap
       - tuned
       - xauth
       - xkbcomp

--- a/data/products/sle-micro/5.3/packages.yaml
+++ b/data/products/sle-micro/5.3/packages.yaml
@@ -2,3 +2,7 @@ packages:
   _namespace_sle_micro_network_mgmt:
     package:
       - NetworkManager
+      - NetworkManager-branding-SLE
+  _namespace_yast2_schema:
+    package:
+      - yast2-schema-micro

--- a/data/products/sle15/defaults.yaml
+++ b/data/products/sle15/defaults.yaml
@@ -2,3 +2,7 @@ archive:
   _namespace_default_motd:
     _include_overlays:
       - motd-default
+packages:
+  _namespace_yast2_schema:
+    package:
+      - yast2-schema

--- a/data/products/sle15/sp4/defaults.yaml
+++ b/data/products/sle15/sp4/defaults.yaml
@@ -1,0 +1,4 @@
+packages:
+  _namespace_yast2_schema:
+    package:
+      - yast2-schema-default


### PR DESCRIPTION
This PR removes packages that are not supported (anymore) or were not released. Details:

- Remove rsyslog and wget from SLE Micro
- Remove yast2-trans_en_US from 15 SP2+
- Remove vlan (still supported via legacy module but simply obsolete)
- Adjust for yast2-schema successors yast2-schema-default and yast2-schema-micro
- Remove a few packages from SAPCAL that were not released
- Remove a few packages from SAPCAL SP3+ there were dropped from SLE
- Remove not-for-install system-role-sles4sap from SAP module