### PR TITLE
Add Support for SAP Converged Cloud

### DIFF
--- a/data/csp/sap-converged-cloud/sle15/config.yaml
+++ b/data/csp/sap-converged-cloud/sle15/config.yaml
@@ -1,0 +1,11 @@
+config:
+  scripts:
+    openstack-config:
+      - ssh-disable-challenge-response-auth
+      - ssh-disable-password-login
+  services:
+    openstack-cloud-init:
+      - cloud-init-local
+      - cloud-init
+      - cloud-config
+      - cloud-final

--- a/data/csp/sap-converged-cloud/sle15/packages.yaml
+++ b/data/csp/sap-converged-cloud/sle15/packages.yaml
@@ -1,11 +1,7 @@
 packages:
   _namespace_default_bootloader: Null
   _namespace_default_shim: Null
-  _namespace_openstack_bootloader:
-    package:
-      - _attributes:
-          name: grub2-arm64-efi
-          arch: aarch64
+  _namespace_openstack_bootloader: Null
   _namespace_openstack_init:
     package:
       - cloud-init

--- a/data/csp/sap-converged-cloud/sle15/packages.yaml
+++ b/data/csp/sap-converged-cloud/sle15/packages.yaml
@@ -1,0 +1,12 @@
+packages:
+  _namespace_default_bootloader: Null
+  _namespace_default_shim: Null
+  _namespace_openstack_bootloader:
+    package:
+      - _attributes:
+          name: grub2-arm64-efi
+          arch: aarch64
+  _namespace_openstack_init:
+    package:
+      - cloud-init
+      - open-vm-tools

--- a/data/csp/sap-converged-cloud/sle15/preferences.yaml
+++ b/data/csp/sap-converged-cloud/sle15/preferences.yaml
@@ -9,10 +9,10 @@ preferences:
         NON_PERSISTENT_DEVICE_NAMES: 1
         multipath: "off"
       vga: normal
-      machine:
+    machine:
+      _attributes:
+        ovftype: vmware
+        HWversion: 10
+      vmdisk:
         _attributes:
-          ovftype: vmware
-          HWversion: 10
-        vmdisk:
-          _attributes:
-            diskmode: streamOptimized
+          diskmode: streamOptimized

--- a/data/csp/sap-converged-cloud/sle15/preferences.yaml
+++ b/data/csp/sap-converged-cloud/sle15/preferences.yaml
@@ -1,0 +1,18 @@
+preferences:
+  type:
+    _attributes:
+      devicepersistency: Null
+      format: vmdk
+      firmware: uefi
+      kernelcmdline:
+        console: ["ttyS0,115200n8", "tty0"]
+        NON_PERSISTENT_DEVICE_NAMES: 1
+        multipath: "off"
+      vga: normal
+      machine:
+        _attributes:
+          ovftype: vmware
+          HWversion: 10
+        vmdisk:
+          _attributes:
+            diskmode: streamOptimized

--- a/images/cross-cloud/sles/chost/15-sp1/content.yaml
+++ b/images/cross-cloud/sles/chost/15-sp1/content.yaml
@@ -17,7 +17,7 @@ image:
           name: OpenStack
           description: OpenStack configuration
       - _attributes:
-          name: SAP Converged Cloud
+          name: SAP-CCloud
           description: SAP Converged Cloud configuration
   preferences:
     - _include:
@@ -48,7 +48,7 @@ image:
         - csp/openstack/settings/chost
         - products/chost
     - attributes:
-        profiles: [SAP Converged Cloud]
+        profiles: [SAP-CCloud]
       _include:
         - csp/sap-converged-cloud/settings/chost
         - products/chost
@@ -101,7 +101,7 @@ image:
         - csp/openstack/settings/chost
     - _attributes:
         type: image
-        profiles: [SAP Converged Cloud]
+        profiles: [SAP-CCloud]
       _include:
         - csp/sap-converged-cloud/settings/chost
 config:
@@ -123,7 +123,7 @@ config:
   - profiles: [OpenStack]
     _include:
       - csp/openstack/settings/chost
-  - profiles: [SAP Converged Cloud]
+  - profiles: [SAP-CCloud]
     _include:
       - csp/sap-converged-cloud/settings/chost
 archive:

--- a/images/cross-cloud/sles/chost/15-sp1/content.yaml
+++ b/images/cross-cloud/sles/chost/15-sp1/content.yaml
@@ -47,7 +47,7 @@ image:
       _include:
         - csp/openstack/settings/chost
         - products/chost
-    - attributes:
+    - _attributes:
         profiles: [SAP-CCloud]
       _include:
         - csp/sap-converged-cloud/settings/chost

--- a/images/cross-cloud/sles/chost/15-sp1/content.yaml
+++ b/images/cross-cloud/sles/chost/15-sp1/content.yaml
@@ -16,6 +16,9 @@ image:
       - _attributes:
           name: OpenStack
           description: OpenStack configuration
+      - _attributes:
+          name: SAP Converged Cloud
+          description: SAP Converged Cloud configuration
   preferences:
     - _include:
         - base/common
@@ -44,9 +47,14 @@ image:
       _include:
         - csp/openstack/settings/chost
         - products/chost
+    - attributes:
+        profiles: [SAP Converged Cloud]
+      _include:
+        - csp/sap-converged-cloud/settings/chost
+        - products/chost
   packages:
     - _attributes:
-       type: bootstrap
+        type: bootstrap
       _include:
         - base/bootstrap
     - _attributes:
@@ -91,6 +99,11 @@ image:
         profiles: [OpenStack]
       _include:
         - csp/openstack/settings/chost
+    - _attributes:
+        type: image
+        profiles: [SAP Converged Cloud]
+      _include:
+        - csp/sap-converged-cloud/settings/chost
 config:
   - _include:
       - base/common
@@ -110,6 +123,9 @@ config:
   - profiles: [OpenStack]
     _include:
       - csp/openstack/settings/chost
+  - profiles: [SAP Converged Cloud]
+    _include:
+      - csp/sap-converged-cloud/settings/chost
 archive:
   - name: root.tar.gz
     _include:

--- a/images/cross-cloud/sles/chost/15-sp4/preferences.yaml
+++ b/images/cross-cloud/sles/chost/15-sp4/preferences.yaml
@@ -35,3 +35,8 @@ image:
       _include:
         - csp/openstack/settings/chost
         - products/chost
+    - _attributes:
+        profiles: [SAP Converged Cloud]
+      _include:
+        - csp/sap-converged-cloud/settings/chost
+        - products/chost

--- a/images/cross-cloud/sles/chost/15-sp4/preferences.yaml
+++ b/images/cross-cloud/sles/chost/15-sp4/preferences.yaml
@@ -36,7 +36,7 @@ image:
         - csp/openstack/settings/chost
         - products/chost
     - _attributes:
-        profiles: [SAP Converged Cloud]
+        profiles: [SAP-CCloud]
       _include:
         - csp/sap-converged-cloud/settings/chost
         - products/chost

--- a/images/cross-cloud/sles/chost/15-sp5/preferences.yaml
+++ b/images/cross-cloud/sles/chost/15-sp5/preferences.yaml
@@ -35,3 +35,8 @@ image:
       _include:
         - csp/openstack/settings/chost
         - products/chost
+    - _attributes:
+        profiles: [SAP Converged Cloud]
+      _include:
+        - csp/sap-converged-cloud/settings/chost
+        - products/chost

--- a/images/cross-cloud/sles/chost/15-sp5/preferences.yaml
+++ b/images/cross-cloud/sles/chost/15-sp5/preferences.yaml
@@ -36,7 +36,7 @@ image:
         - csp/openstack/settings/chost
         - products/chost
     - _attributes:
-        profiles: [SAP Converged Cloud]
+        profiles: [SAP-CCloud]
       _include:
         - csp/sap-converged-cloud/settings/chost
         - products/chost

--- a/images/cross-cloud/sles/chost/content.yaml
+++ b/images/cross-cloud/sles/chost/content.yaml
@@ -16,6 +16,9 @@ image:
       - _attributes:
           name: OpenStack
           description: OpenStack configuration
+      - _attributes:
+          name: SAP Converged Cloud
+          description: SAP Converged Cloud configuration
   preferences:
     - _include:
         - base/common
@@ -44,9 +47,14 @@ image:
       _include:
         - csp/openstack/settings/chost
         - products/chost
+    - _attributes:
+        profiles: [SAP Converged Cloud]
+      _include:
+        - csp/sap-converged-cloud/settings/chost
+        - products/chost
   packages:
     - _attributes:
-       type: bootstrap
+        type: bootstrap
       _include:
         - base/bootstrap
     - _attributes:
@@ -91,6 +99,11 @@ image:
         profiles: [OpenStack]
       _include:
         - csp/openstack/settings/chost
+    - _attributes:
+        type: image
+        profiles: [SAP Converged Cloud]
+      _include:
+        - csp/sap-converged-cloud/settings/chost
 config:
   - _include:
       - base/common
@@ -110,6 +123,9 @@ config:
   - profiles: [OpenStack]
     _include:
       - csp/openstack/settings/chost
+  - profiles: [SAP Converged Cloud]
+    _include:
+      - csp/sap-converged-cloud/settings/chost
 archive:
   - name: root.tar.gz
     _include:

--- a/images/cross-cloud/sles/chost/content.yaml
+++ b/images/cross-cloud/sles/chost/content.yaml
@@ -17,7 +17,7 @@ image:
           name: OpenStack
           description: OpenStack configuration
       - _attributes:
-          name: SAP Converged Cloud
+          name: SAP-CCloud
           description: SAP Converged Cloud configuration
   preferences:
     - _include:
@@ -48,7 +48,7 @@ image:
         - csp/openstack/settings/chost
         - products/chost
     - _attributes:
-        profiles: [SAP Converged Cloud]
+        profiles: [SAP-CCloud]
       _include:
         - csp/sap-converged-cloud/settings/chost
         - products/chost
@@ -101,7 +101,7 @@ image:
         - csp/openstack/settings/chost
     - _attributes:
         type: image
-        profiles: [SAP Converged Cloud]
+        profiles: [SAP-CCloud]
       _include:
         - csp/sap-converged-cloud/settings/chost
 config:
@@ -123,7 +123,7 @@ config:
   - profiles: [OpenStack]
     _include:
       - csp/openstack/settings/chost
-  - profiles: [SAP Converged Cloud]
+  - profiles: [SAP-CCloud]
     _include:
       - csp/sap-converged-cloud/settings/chost
 archive:


### PR DESCRIPTION
SAP Converged Cloud (CCloud) runs OpenStack on ESXi. With that, some kind of hybrid is necessary to make images available.

On one hand, all the OpenStack support is necessary (cloud-init mainly), on the other hand VMware-specifics like image format and other metadata needs to be considered.

Closes: #185 