### PR TITLE
SAP-CCloud: include grub2-efi and shim packages

### DIFF
--- a/data/csp/sap-converged-cloud/sle15/packages.yaml
+++ b/data/csp/sap-converged-cloud/sle15/packages.yaml
@@ -1,7 +1,4 @@
 packages:
-  _namespace_default_bootloader: Null
-  _namespace_default_shim: Null
-  _namespace_openstack_bootloader: Null
   _namespace_openstack_init:
     package:
       - cloud-init


### PR DESCRIPTION
@killermoehre @sandzwerg The SAP-CCloud profile uses firmware `uefi` but doesn't include grub2-x86_64-efi which results in build failure. This PR adds that and `shim`. Let me know if that's correct setup for SAP Converged Cloud.