### PR TITLE
Avoid OBS conflict with rpm

### DIFF
--- a/images/single-cloud/oci/sles-byos/15-sp3/obs-comments.yaml
+++ b/images/single-cloud/oci/sles-byos/15-sp3/obs-comments.yaml
@@ -1,0 +1,2 @@
+image-config-comments:
+  obs-ignore-rpm: "OBS-IgnorePackage: rpm"


### PR DESCRIPTION
Add "OBS-IgnorePackage: rpm" comment to avoid 'rpm-ndb' vs 'rpm' conflict when building in OBS.