### PR TITLE
Include sle-micro-ec2-pubcloud-release

### DIFF
--- a/data/csp/ec2/settings/micro/sle15/sp4/packages.yaml
+++ b/data/csp/ec2/settings/micro/sle15/sp4/packages.yaml
@@ -9,3 +9,4 @@ packages:
   _namespace_ec2_imgutils:
     package:
       - python3-ec2imgutils
+      - sle-module-public-cloud-release


### PR DESCRIPTION
Include sle-micro-ec2-pubcloud-release in EC2 profile, since included ec2imgutils is part of that channel.