### PR TITLE
Replace 'command-not-found' with 'scout-command-not-found' in 15 SP5

### DIFF
--- a/data/base/sle/sle15/packages.yaml
+++ b/data/base/sle/sle15/packages.yaml
@@ -10,7 +10,6 @@ packages:
       - binutils
       - blktrace
       - cifs-utils
-      - command-not-found
       - crash
       - cronie
       - curl
@@ -118,3 +117,6 @@ packages:
   _namespace_sle_common_yast2_trans:
     package:
       - yast2-trans-en_US
+  _namespace_sle_cnf:
+    package:
+      - command-not-found

--- a/data/base/sle/sle15/sp5/packages.yaml
+++ b/data/base/sle/sle15/sp5/packages.yaml
@@ -1,0 +1,4 @@
+packages:
+  _namespace_sle_cnf:
+    package:
+      - scout-command-not-found


### PR DESCRIPTION
The SLES 15 SP5 Public Cloud images are failing to build due to scout [SR#289321](https://build.suse.de/request/show/289321) rename command-not-found to scout-command-not-found.