### PR TITLE
Add relp package to support log exporting via the relp protocol in CHOST

### DIFF
--- a/data/products/chost/sle15/packages.yaml
+++ b/data/products/chost/sle15/packages.yaml
@@ -15,6 +15,7 @@ packages:
       - jq
       - less
       - libnss_usrfiles2
+      - librelp0
       - nfs-client
       - open-iscsi
       - pciutils


### PR DESCRIPTION
SAP is using relp to export log files. Include the librelp0 package to support the protocol.