### PR TITLE
Remove package sle-module-legacy-release from SLE15 SP3+

### DIFF
--- a/data/base/ondemand/sle15/packages.yaml
+++ b/data/base/ondemand/sle15/packages.yaml
@@ -5,9 +5,11 @@ packages:
       - sle-module-containers-release
       - sle-module-desktop-applications-release
       - sle-module-development-tools-release
-      - sle-module-legacy-release
       - sle-module-server-applications-release
       - sle-module-web-scripting-release
   _namespace_sle_module_cap_tools:
     package:
       - sle-module-cap-tools-release
+  _namespace_sle_module_legacy:
+    package:
+      - sle-module-legacy-release

--- a/data/base/ondemand/sle15/sp3/packages.yaml
+++ b/data/base/ondemand/sle15/sp3/packages.yaml
@@ -1,0 +1,2 @@
+packages:
+  _namespace_sle_module_legacy: Null


### PR DESCRIPTION
Drop `sle-module-legacy-release` from all SLE15 SP3+ PAYG image definitions. SAPCAL and Azure baremetal are not affected.