### PR TITLE
Replace SUSEConnect with suseconnect-ng

### DIFF
--- a/data/base/common/sle15/packages.yaml
+++ b/data/base/common/sle15/packages.yaml
@@ -15,7 +15,6 @@ packages:
       - sudo
       - supportutils
       - suse-build-key
-      - SUSEConnect
       - system-group-hardware
       - system-group-wheel
       - system-user-nobody

--- a/data/products/sle-micro/packages.yaml
+++ b/data/products/sle-micro/packages.yaml
@@ -47,3 +47,6 @@ packages:
     package:
       - cockpit-wicked
       - wicked
+  _namespace_suseconnect:
+    package:
+      - suseconnect-ng

--- a/data/products/sle15/defaults.yaml
+++ b/data/products/sle15/defaults.yaml
@@ -3,6 +3,9 @@ archive:
     _include_overlays:
       - motd-default
 packages:
+  _namespace_suseconnect:
+    package:
+      - SUSEConnect
   _namespace_yast2_schema:
     package:
       - yast2-schema

--- a/data/products/sle15/sp4/defaults.yaml
+++ b/data/products/sle15/sp4/defaults.yaml
@@ -1,4 +1,7 @@
 packages:
+  _namespace_suseconnect:
+    package:
+      - suseconnect-ng
   _namespace_yast2_schema:
     package:
       - yast2-schema-default


### PR DESCRIPTION
Use suseconnect-ng instead of SUSEConnect in SLE 15 SP4+ based products. Use suseconnect-ng in SLE Micro products.