### PR TITLE
Add new package to Micro 5.4

### DIFF
--- a/data/products/sle-micro/5.4/packages.yaml
+++ b/data/products/sle-micro/5.4/packages.yaml
@@ -1,0 +1,4 @@
+packages:
+  _namespace_sle_micro_pwd_check:
+    package:
+      - libpwquality-tools


### PR DESCRIPTION
For bsc#1202277 Cockpit introduced password strength checkeing this introduced a file dependency in packaging on pwscore. FIle dependencies are not properly resolved in the build service, add a direct package dependency for the image build on libpwquality-tools.