### PR TITLE
Remove cgroup_enable=memory

### DIFF
--- a/data/products/chost/sle15/preferences.yaml
+++ b/data/products/chost/sle15/preferences.yaml
@@ -2,5 +2,4 @@ preferences:
   type:
     _attributes:
       kernelcmdline:
-        cgroup_enable: memory
         swapaccount: 1

--- a/data/products/sle-micro/preferences.yaml
+++ b/data/products/sle-micro/preferences.yaml
@@ -12,7 +12,6 @@ preferences:
       spare_part_is_last: "true"
       spare_part_fs_attributes: no-copy-on-write
       kernelcmdline:
-        cgroup_enable: memory
         swapaccount: 1
         ip: dhcp
         rd.neednet: 1


### PR DESCRIPTION
This is a no op and has always been a no op. In more recent kernels this triggers warning in the log. Remove the setting to avoid the warning.