### PR TITLE
Remove java

### DIFF
--- a/data/products/sap/sle15/packages.yaml
+++ b/data/products/sap/sle15/packages.yaml
@@ -13,7 +13,6 @@ packages:
       - HANA-Firewall
       - hawk2
       - ipmitool
-      - java-1_8_0-ibm
       - libatomic1
       - libdlm
       - libgthread-2_0-0


### PR DESCRIPTION
SAP applications no longer need our version of java. Remove it from the images.