### PR TITLE
Enable cloud-netconfig timer in GCE image definitions

### DIFF
--- a/data/csp/gce/settings/chost/sle15/config.yaml
+++ b/data/csp/gce/settings/chost/sle15/config.yaml
@@ -1,3 +1,5 @@
 config:
+  services:
+    gce-cloud-netconfig: Null
   sysconfig:
     gce-sysconfig-netconfig: Null

--- a/data/csp/gce/sle12/config.yaml
+++ b/data/csp/gce/sle12/config.yaml
@@ -40,3 +40,5 @@ config:
       - google-shutdown-scripts
       - google-startup-scripts
       - rootgrow
+    gce-cloud-netconfig:
+      - cloud-netconfig.timer

--- a/data/csp/gce/sle15/config.yaml
+++ b/data/csp/gce/sle15/config.yaml
@@ -37,3 +37,5 @@ config:
       - google-shutdown-scripts
       - google-startup-scripts
       - rootgrow
+    gce-cloud-netconfig:
+      - cloud-netconfig.timer


### PR DESCRIPTION
With the release of version 1.7, cloud-netconfig supports configuring routing policies for IPv4 ranges in GCE. Since IP range configurations can be altered framework-side at runtime, it makes sense to enable the timer to automatically pick up changes.