### PR TITLE
Add supportutils-plugin-suse-public-cloud to SLE Micro

### DIFF
--- a/data/csp/azure/settings/micro/sle15/packages.yaml
+++ b/data/csp/azure/settings/micro/sle15/packages.yaml
@@ -4,6 +4,7 @@ packages:
   _namespace_azure_tools: Null
   _namespace_azure_regionsrv_client_addon: Null
   _namespace_azure_registration: Null
-  _namespace_azure_micro_os:
+  _namespace_azure_micro:
     package:
       - afterburn-dracut
+      - python3-azuremetadata

--- a/data/csp/ec2/settings/micro/sle15/packages.yaml
+++ b/data/csp/ec2/settings/micro/sle15/packages.yaml
@@ -1,5 +1,8 @@
 packages:
-  _namespace_ec2_init: NULL
+  _namespace_ec2_init: Null
   _namespace_ec2_tools: Null
   _namespace_ec2_image_utils: Null
   _namespace_ec2_registration: Null
+  _namespace_ec2_micro:
+    package:
+      - python3-ec2metadata

--- a/data/csp/gce/settings/micro/sle15/packages.yaml
+++ b/data/csp/gce/settings/micro/sle15/packages.yaml
@@ -3,3 +3,6 @@ packages:
   _namespace_gce_patch: Null
   _namespace_gce_tools: Null
   _namespace_gce_registration: Null
+  _namespace_gce_micro:
+    package:
+      - python3-gcemetadata

--- a/data/products/sle-micro/packages.yaml
+++ b/data/products/sle-micro/packages.yaml
@@ -35,6 +35,7 @@ packages:
       - rollback-helper
       - selinux-policy-targeted
       - selinux-tools
+      - supportutils-plugin-suse-public-cloud
       - systemd-presets-branding-SMO
       - systemd-default-settings-branding-SLE-Micro
       - SUSE-MicroOS-release


### PR DESCRIPTION
Add supportutils-plugin-suse-public-cloud package to SLE Micro product module.
Add metadata lookup packages required by supportutils-plugin-suse-public-cloud to the framework specific SLEM settings modules.