### PR TITLE
Drop unsupported packages from SAPCAL

### DIFF
--- a/data/products/sapcal/sle15/packages.yaml
+++ b/data/products/sapcal/sle15/packages.yaml
@@ -39,27 +39,19 @@ packages:
       - libssh2-1
       - libtool
       - libxml2-devel
-      - opie
-      - python2-pycrypto
-      - python-pyOpenSSL
       - readline-devel
       - rpm-build
       - samba
       - samba-client
-      - _attributes:
-          name: samba-client-32bit
-          arch: x86_64
       - sapconf
       - sysstat
       - tack
       - tuned
       - unrar
       - uuidd
-      - uuid-runtime
       - x11-tools
       - xauth
       - xorg-x11-devel
-      - xorg-x11-driver-input
       - xorg-x11-driver-video
       - xorg-x11-fonts
       - xorg-x11-server
@@ -68,9 +60,6 @@ packages:
           arch: x86_64
       - _attributes:
           name: xorg-x11-libXau-32bit
-          arch: x86_64
-      - _attributes:
-          name: xorg-x11-libXdmcp-32bit
           arch: x86_64
       - _attributes:
           name: xorg-x11-libXext-32bit
@@ -82,3 +71,13 @@ packages:
       - _attributes:
           name: zlib-32bit
           arch: x86_64
+  _namespace_sapcal_legacy:
+    package:
+      - _attributes:
+          name: glibc-32bit
+          arch: x86_64
+      - _attributes:
+          name: samba-client-32bit
+          arch: x86_64
+      - python2-pycrypto
+      - python-pyOpenSSL

--- a/data/products/sapcal/sle15/sp3/packages.yaml
+++ b/data/products/sapcal/sle15/sp3/packages.yaml
@@ -23,13 +23,11 @@ packages:
           name: libodbc2
           arch: x86_64
       - _attributes:
-          name: libopenssl1_0_0
-          arch: x86_64
-      - _attributes:
           name: unixODBC
           arch: x86_64
-  _namespace_sapcal_legacy: Null
-  _namespace_sapcal_java_legacy:
+  _namespace_sapcal_libopenssl_old:
     package:
-      # java-1_8_0-ibm moved to legacy module in SP3
-      - sle-module-legacy-release
+      - _attributes:
+          name: libopenssl1_0_0
+          arch: x86_64
+  _namespace_sapcal_legacy: Null

--- a/data/products/sapcal/sle15/sp3/packages.yaml
+++ b/data/products/sapcal/sle15/sp3/packages.yaml
@@ -2,9 +2,6 @@ packages:
   _namespace_sapcal_addon_x86:
     package:
       - _attributes:
-          name: glibc-locale-32bit
-          arch: x86_64
-      - _attributes:
           name: libcurl4-32bit
           arch: x86_64
       - _attributes:

--- a/data/products/sapcal/sle15/sp4/packages.yaml
+++ b/data/products/sapcal/sle15/sp4/packages.yaml
@@ -1,0 +1,2 @@
+packages:
+  _namespace_sapcal_libopenssl_old: Null


### PR DESCRIPTION
I noticed this branch when cleaning up merged branches. It removes a few packages from SAPCAL that are not supported. I think this was part of a PR at some point but needed clarification or something, and then fell of the radar. I've updated it to remove `sle-module-legacy-release` as well.

Azure LI/VLI also includes a few of those packages and should perhaps be updated as well.