### PR TITLE
Bug 1210579 - Include toolbox package by default in SLE Micro images

### DIFF
--- a/data/products/sle-micro/packages.yaml
+++ b/data/products/sle-micro/packages.yaml
@@ -39,6 +39,7 @@ packages:
       - systemd-presets-branding-SMO
       - systemd-default-settings-branding-SLE-Micro
       - SUSE-MicroOS-release
+      - toolbox
       - transactional-update
       - transactional-update-zypp-config
       - vim-small


### PR DESCRIPTION
Toolbox is able to work with podman (preferred) or docker ([here](https://github.com/openSUSE/microos-toolbox/blob/master/toolbox#L27)) so there is not required to change the container runtime (for toolbox at least).

I did some tests with image clouds for Micro 5.1 to 5.4 and toolbox works out of the box after installing it.
