### PR TITLE
Add rsyslog relp support

### DIFF
--- a/data/products/chost/sle15/packages.yaml
+++ b/data/products/chost/sle15/packages.yaml
@@ -21,6 +21,7 @@ packages:
       - open-iscsi
       - pciutils
       - rsyslog
+      - rsyslog-module-relp
       - runc
       - socat
       - supportutils-plugin-suse-public-cloud


### PR DESCRIPTION
SAP uses relp to export logs let rsyslog send the messages directly for log export