### PR TITLE
Inherit SLE Micro 5.3 configuration

### DIFF
--- a/images/cross-cloud/sle-micro/byos/5.4/image.yaml
+++ b/images/cross-cloud/sle-micro/byos/5.4/image.yaml
@@ -3,6 +3,7 @@ include-paths:
   - sle15/sp2
   - sle15/sp3
   - sle15/sp4
+  - "5.3"
   - "5.4"
 image:
   _attributes:

--- a/images/cross-cloud/sle-micro/ondemand/5.4/image.yaml
+++ b/images/cross-cloud/sle-micro/ondemand/5.4/image.yaml
@@ -3,6 +3,7 @@ include-paths:
   - sle15/sp2
   - sle15/sp3
   - sle15/sp4
+  - "5.3"
   - "5.4"
 image:
   _attributes:


### PR DESCRIPTION
Inherit the SLE Micro 5.3 configuration in the SLE Micro 5.4 image definitions. This switches the network system from wicked to NetworkManager.