### PR TITLE
Set EC2 profile name to 'EC2-HVM'

### DIFF
--- a/images/cross-cloud/sle-micro/byos/5.1/content.yaml
+++ b/images/cross-cloud/sle-micro/byos/5.1/content.yaml
@@ -1,0 +1,89 @@
+image:
+  profiles:
+    profile:
+      - _attributes:
+          name: Azure
+          description: Azure Guest Image
+      - _attributes:
+          name: EC2-HVM
+          description: EC2 Guest Image
+      - _attributes:
+          name: GCE
+          description: GCE Guest Image
+  preferences:
+    - _include: base/common
+    - _attributes:
+        profiles: [Azure]
+      _include:
+        - csp/azure/settings/micro
+        - products/sle-micro
+    - _attributes:
+        profiles: [EC2-HVM]
+      _include:
+        - csp/ec2/settings/micro
+        - products/sle-micro
+    - _attributes:
+        profiles: [GCE]
+      _include:
+        - csp/gce/settings/micro
+        - products/sle-micro
+  packages:
+    - _attributes:
+       type: bootstrap
+      _include:
+        - base/bootstrap
+    - _attributes:
+        type: image
+      _include:
+        - base/common
+        - products/sle-micro
+    - _attributes:
+        type: image
+        profiles: [Azure]
+      _include:
+        - csp/azure/settings/micro
+      archive:
+        - _attributes:
+            name: azure.tar.gz
+    - _attributes:
+        type: image
+        profiles: [EC2-HVM]
+      _include:
+        - csp/ec2/settings/micro
+      archive:
+        - _attributes:
+            name: ec2.tar.gz
+    - _attributes:
+        type: image
+        profiles: [GCE]
+      _include:
+        - csp/gce/settings/micro
+      archive:
+        - _attributes:
+            name: gce.tar.gz
+config:
+  - _include:
+      - base/common
+      - products/sle-micro
+  - profiles: [Azure]
+    _include:
+      - csp/azure/settings/micro
+  - profiles: [EC2-HVM]
+    _include:
+      - csp/ec2/settings/micro
+  - profiles: [GCE]
+    _include:
+      - csp/gce/settings/micro
+archive:
+  - name: root.tar.gz
+    _include:
+      - products/sle-micro
+  - name: azure.tar.gz
+    _include:
+      - csp/azure/settings/micro
+  - name: ec2.tar.gz
+    _include:
+      - csp/ec2/settings/micro
+  - name: gce.tar.gz
+    _include:
+      - csp/gce/settings/micro

--- a/images/cross-cloud/sle-micro/byos/5.2/content.yaml
+++ b/images/cross-cloud/sle-micro/byos/5.2/content.yaml
@@ -1,0 +1,89 @@
+image:
+  profiles:
+    profile:
+      - _attributes:
+          name: Azure
+          description: Azure Guest Image
+      - _attributes:
+          name: EC2-HVM
+          description: EC2 Guest Image
+      - _attributes:
+          name: GCE
+          description: GCE Guest Image
+  preferences:
+    - _include: base/common
+    - _attributes:
+        profiles: [Azure]
+      _include:
+        - csp/azure/settings/micro
+        - products/sle-micro
+    - _attributes:
+        profiles: [EC2-HVM]
+      _include:
+        - csp/ec2/settings/micro
+        - products/sle-micro
+    - _attributes:
+        profiles: [GCE]
+      _include:
+        - csp/gce/settings/micro
+        - products/sle-micro
+  packages:
+    - _attributes:
+       type: bootstrap
+      _include:
+        - base/bootstrap
+    - _attributes:
+        type: image
+      _include:
+        - base/common
+        - products/sle-micro
+    - _attributes:
+        type: image
+        profiles: [Azure]
+      _include:
+        - csp/azure/settings/micro
+      archive:
+        - _attributes:
+            name: azure.tar.gz
+    - _attributes:
+        type: image
+        profiles: [EC2-HVM]
+      _include:
+        - csp/ec2/settings/micro
+      archive:
+        - _attributes:
+            name: ec2.tar.gz
+    - _attributes:
+        type: image
+        profiles: [GCE]
+      _include:
+        - csp/gce/settings/micro
+      archive:
+        - _attributes:
+            name: gce.tar.gz
+config:
+  - _include:
+      - base/common
+      - products/sle-micro
+  - profiles: [Azure]
+    _include:
+      - csp/azure/settings/micro
+  - profiles: [EC2-HVM]
+    _include:
+      - csp/ec2/settings/micro
+  - profiles: [GCE]
+    _include:
+      - csp/gce/settings/micro
+archive:
+  - name: root.tar.gz
+    _include:
+      - products/sle-micro
+  - name: azure.tar.gz
+    _include:
+      - csp/azure/settings/micro
+  - name: ec2.tar.gz
+    _include:
+      - csp/ec2/settings/micro
+  - name: gce.tar.gz
+    _include:
+      - csp/gce/settings/micro

--- a/images/cross-cloud/sles-sap/byos/15-sp3/content.yaml
+++ b/images/cross-cloud/sles-sap/byos/15-sp3/content.yaml
@@ -1,0 +1,90 @@
+image:
+  profiles:
+    profile:
+      - _attributes:
+          name: Azure
+          description: Azure configuration
+      - _attributes:
+          name: EC2-HVM
+          description: EC2 configuration
+      - _attributes:
+          name: GCE
+          description: GCE configuration
+  preferences:
+    - _include:
+        - base/common
+    - _attributes:
+        profiles: [Azure]
+      _include:
+        - csp/azure/settings/sap/byos
+    - _attributes:
+        profiles: [EC2-HVM]
+      _include:
+        - csp/ec2/settings/sap/byos
+    - _attributes:
+        profiles: [GCE]
+      _include: csp/gce/settings/sap/byos
+  packages:
+    - _attributes:
+       type: bootstrap
+      _include:
+        - base/bootstrap
+    - _attributes:
+        type: image
+      _include:
+        - base/common
+        - base/sle
+        - products/sap/byos
+    - _attributes:
+        type: image
+        profiles: [Azure]
+      _include:
+        - csp/azure/settings/sap/byos
+      archive:
+        - _attributes:
+            name: azure.tar.gz
+    - _attributes:
+        type: image
+        profiles: [EC2-HVM]
+      _include:
+        - csp/ec2/settings/sap/byos
+      archive:
+        - _attributes:
+            name: ec2.tar.gz
+    - _attributes:
+        type: image
+        profiles: [GCE]
+      _include:
+        - csp/gce/settings/sap/byos
+      archive:
+        - _attributes:
+            name: gce.tar.gz
+config:
+  - _include:
+      - base/common
+      - base/sle
+      - products/sap/byos
+  - profiles: [Azure]
+    _include:
+      - csp/azure/settings/sap/byos
+  - profiles: [EC2-HVM]
+    _include:
+      - csp/ec2/settings/sap/byos
+  - profiles: [GCE]
+    _include:
+      - csp/gce/settings/sap/byos
+archive:
+  - name: root.tar.gz
+    _include:
+      - base/common
+      - base/sle
+      - products/sap/byos
+  - name: azure.tar.gz
+    _include:
+      - csp/azure/settings/sap/byos
+  - name: ec2.tar.gz
+    _include:
+      - csp/ec2/settings/sap/byos
+  - name: gce.tar.gz
+    _include:
+      - csp/gce/settings/sap/byos

--- a/images/cross-cloud/sles-sap/ondemand/15-sp3/content.yaml
+++ b/images/cross-cloud/sles-sap/ondemand/15-sp3/content.yaml
@@ -1,0 +1,93 @@
+image:
+  profiles:
+    profile:
+      - _attributes:
+          name: Azure
+          description: Azure configuration
+      - _attributes:
+          name: EC2-HVM
+          description: EC2 configuration
+      - _attributes:
+          name: GCE
+          description: GCE configuration
+  preferences:
+    - _include:
+        - base/common
+    - _attributes:
+        profiles: [Azure]
+      _include:
+        - csp/azure/settings/sap/ondemand
+    - _attributes:
+        profiles: [EC2-HVM]
+      _include:
+        - csp/ec2/settings/sap/ondemand
+    - _attributes:
+        profiles: [GCE]
+      _include: csp/gce/settings/sap/ondemand
+  packages:
+    - _attributes:
+       type: bootstrap
+      _include:
+        - base/bootstrap
+    - _attributes:
+        type: image
+      _include:
+        - base/common
+        - base/ondemand
+        - base/sle
+        - products/sap/ondemand
+    - _attributes:
+        type: image
+        profiles: [Azure]
+      _include:
+        - csp/azure/settings/sap/ondemand
+      archive:
+        - _attributes:
+            name: azure.tar.gz
+    - _attributes:
+        type: image
+        profiles: [EC2-HVM]
+      _include:
+        - csp/ec2/settings/sap/ondemand
+      archive:
+        - _attributes:
+            name: ec2.tar.gz
+    - _attributes:
+        type: image
+        profiles: [GCE]
+      _include:
+        - csp/gce/settings/sap/ondemand
+      archive:
+        - _attributes:
+            name: gce.tar.gz
+config:
+  - _include:
+      - base/common
+      - base/ondemand
+      - base/sle
+      - products/sap/ondemand
+  - profiles: [Azure]
+    _include:
+      - csp/azure/settings/sap/ondemand
+  - profiles: [EC2-HVM]
+    _include:
+      - csp/ec2/settings/sap/ondemand
+  - profiles: [GCE]
+    _include:
+      - csp/gce/settings/sap/ondemand
+archive:
+  - name: root.tar.gz
+    _include:
+      - base/common
+      - base/ondemand
+      - base/sle
+      - products/sap/ondemand
+  - name: azure.tar.gz
+    _include:
+      - csp/azure/settings/sap/ondemand
+  - name: ec2.tar.gz
+    _include:
+      - csp/ec2/settings/sap/ondemand
+  - name: gce.tar.gz
+    _include:
+      - csp/gce/settings/sap/ondemand


### PR DESCRIPTION
Uset 'EC2-HVM' as profile name for EC2 in 15 SP3 based SLES for SAP and SLE Micro image descriptions.

Unfortunately that effectively duplicates the image content definitions for those images, but there isn't really a way to avoid this. Should we also rename the profiles for SLES BYOS and SLE HPC BYOS, just in case?