### PR TITLE
Disable sudo targetpw directive (bsc#1207076)

### DIFF
--- a/data/csp/azure/sle15/config.yaml
+++ b/data/csp/azure/sle15/config.yaml
@@ -3,6 +3,7 @@ config:
     azure-scripts:
       - set-password-policy
       - ssh-enable-keep-alive
+      - sudo-disable-targetpw
     azure-default-kernel-log-level:
       - keep-default-kernel-log-level
     azure-dhclient-timeout:


### PR DESCRIPTION
Remove targetpw from sudo default configuration in Azure. There is no root password and WA Agent (via VMAccess extension) configures user accounts created via framework with a password to ask for a password (i.e. root's), rendering that account unable to assume root (bsc#1207076).