### PR TITLE
Fix dracut 85-ign-usr-config.conf (bsc#1211920)

### DIFF
--- a/data/overlayfiles/ignition-user-config/etc/dracut.conf.d/85-ign-usr-config.conf
+++ b/data/overlayfiles/ignition-user-config/etc/dracut.conf.d/85-ign-usr-config.conf
@@ -1,1 +1,1 @@
-install_items+=" /usr/lib/ignition/base.d/base.ign"
+install_items+=" /usr/lib/ignition/base.d/base.ign "


### PR DESCRIPTION
Add trailing whitespace to dracut install_items command in /etc/dracut.conf.d/85-ign-usr-config.conf to avoid concatenation issues.