### PR TITLE
Fix set-prodlink script

### DIFF
--- a/data/scripts/set-prodlink.sh
+++ b/data/scripts/set-prodlink.sh
@@ -1,10 +1,11 @@
-prodfiles=(`grep -l '<codestream>' /etc/products.d/*prod`)
-for p in $prodfiles ; do
-  grep -q '<flavor>extension</flavor>' $p || prodfile="$prodfile $p"
+readarray -t prodfiles < <(grep -l '<codestream>' /etc/products.d/*prod)
+base_prodfiles=()
+for p in "${prodfiles[@]}" ; do
+    grep -q '<flavor>' "$p" || base_prodfiles+=("$p")
 done
-if [[ ${#prodfile[*]} -ne 1 ]]; then
+if [[ ${#base_prodfiles[*]} -ne 1 ]]; then
     echo "No base product package installed or base product ambiguous." >&2
     false
 else
-    ln -sf `basename "${prodfile[0]}"` /etc/products.d/baseproduct
+    ln -sf `basename "${base_prodfiles[0]}"` /etc/products.d/baseproduct
 fi

--- a/data/scripts/set-prodlink.sh
+++ b/data/scripts/set-prodlink.sh
@@ -1,3 +1,4 @@
+# NOTE: This needs to be adapted to ALP
 readarray -t prodfiles < <(grep -l '<codestream>' /etc/products.d/*prod)
 base_prodfiles=()
 for p in "${prodfiles[@]}" ; do


### PR DESCRIPTION
I noticed that the `set-prodlink` script has a couple of issue. The most important one is that it only actually considers the fist prod file, which seems to typically be the base product file (possibly because they tend to be upper case), but this only really worked by chance so far.

Also, it only filters prod files with `<flavor>extension<flavor>`, but there is also `<flavor>module<flavor>`, and the code that handles ambiguity is broken. Both issues don't actually trigger in practice because `module` type prod files don't seem to contain a `<codestream>` tag, and the first bug prevented that last bug from being triggered (well, if you could actually install multiple base product files, I assume they would conflict).

This PR fixes all of the above.