### PR TITLE
Remove log4j12 from Manager package list

### DIFF
--- a/data/products/suse-manager/server/sle15/packages.yaml
+++ b/data/products/suse-manager/server/sle15/packages.yaml
@@ -20,6 +20,5 @@ packages:
       # direct include to avoid picking classpathx-mail instead of
       # javamail which does not work with spacewalk-java
       - javamail
-      - log4j12
       - python3-numpy
       - python3-PyJWT

--- a/data/products/suse-manager/server/sle15/sp4/packages.yaml
+++ b/data/products/suse-manager/server/sle15/sp4/packages.yaml
@@ -1,8 +1,6 @@
 packages:
   _namespace_manager_server_deps:
     package:
-      # avoid log4j12-mini
-      - log4j12
       # direct include to avoid picking classpathx-mail instead of
       # javamail which does not work with spacewalk-java
       - javamail


### PR DESCRIPTION
Remove log4j12 from Manager server module's package list. log4j12 was included to avoid log4j12-mini, but log4j12 was replaced by reload4j and including it directly causes an unresolvable build.