### PR TITLE
Use oscap with pcs-hardening not remediation script

### DIFF
--- a/data/scripts/pcs-hardening.sh
+++ b/data/scripts/pcs-hardening.sh
@@ -1,2 +1,5 @@
 # run image hardening script
-/usr/bin/bash -e /usr/share/scap-security-guide/bash/sle15-script-pcs-hardening.sh
+echo "run oscap -profile pcs-hardening"
+oscap xccdf eval --remediate --profile pcs-hardening /usr/share/xml/scap/ssg/content/ssg-sle15-ds.xml || {
+    echo "!!!FAILED: --profile pcs-hardening"
+}

--- a/data/scripts/pcs-sap-hardening.sh
+++ b/data/scripts/pcs-sap-hardening.sh
@@ -2,7 +2,6 @@
 echo "run oscap -profile pcs-hardening-sap"
 oscap xccdf eval --remediate --profile pcs-hardening-sap /usr/share/xml/scap/ssg/content/ssg-sle15-ds.xml || {
     echo "!!!FAILED: --profile pcs-hardening-sap"
-    /bin/fail
 }
 
 RULES_FROM_CIS=" \
@@ -53,6 +52,5 @@ for RULE in ${RULES_FROM_CIS}; do
     echo "run oscap -profile cis_server_l ${RULE}"
     oscap xccdf eval --remediate --profile cis_server_l1 --rule xccdf_org.ssgproject.content_rule_${RULE}  /usr/share/xml/scap/ssg/content/ssg-sle15-ds.xml || {
 	echo "!!!FAILED: ${RULE}"
-        /bin/fail
 	}
 done


### PR DESCRIPTION
    Use oscap with pcs-hardening not remediation script
    
    The remediation script:
    /usr/share/scap-security-guide/bash/sle15-script-pcs-hardening.sh
    
    blindly applies remediation even if it is not needed
    
    using:
    oscap xccdf eval --remediate --profile pcs-hardening /usr/share/xml/scap/ssg/content/ssg-sle15-ds.xml
    
    is better, since it will only attempt to apply remediation when needed.
