### PR TITLE
PCS hardening updates

### DIFF
--- a/data/overlayfiles/pcs-hardening-sap/etc/sysctl.d/fs_suid_dumpable.conf
+++ b/data/overlayfiles/pcs-hardening-sap/etc/sysctl.d/fs_suid_dumpable.conf
@@ -1,0 +1,2 @@
+# Per CCE-91447-3: Set fs.suid_dumpable = 0 in /etc/sysctl.d/fs_suid_dumpable.conf
+fs.suid_dumpable = 0

--- a/data/overlayfiles/pcs-hardening-sap/etc/sysctl.d/net_ipv4_conf_all_rp_filter.conf
+++ b/data/overlayfiles/pcs-hardening-sap/etc/sysctl.d/net_ipv4_conf_all_rp_filter.conf
@@ -1,0 +1,2 @@
+# Per CCE-91218-8: Set net.ipv4.conf.all.rp_filter = 1 in /etc/sysctl.d/net_ipv4_conf_all_rp_filter.conf
+net.ipv4.conf.all.rp_filter = 1

--- a/data/overlayfiles/pcs-hardening-sap/etc/sysctl.d/net_ipv4_conf_all_secure_redirects.conf
+++ b/data/overlayfiles/pcs-hardening-sap/etc/sysctl.d/net_ipv4_conf_all_secure_redirects.conf
@@ -1,0 +1,2 @@
+# Per CCE-91220-4: Set net.ipv4.conf.all.secure_redirects = 0 in /etc/sysctl.d/net_ipv4_conf_all_secure_redirects.conf
+net.ipv4.conf.all.secure_redirects = 0

--- a/data/overlayfiles/pcs-hardening-sap/etc/sysctl.d/net_ipv4_conf_default_secure_redirects.conf
+++ b/data/overlayfiles/pcs-hardening-sap/etc/sysctl.d/net_ipv4_conf_default_secure_redirects.conf
@@ -1,0 +1,2 @@
+# Per CCE-91221-2: Set net.ipv4.conf.default.secure_redirects = 0 in /etc/sysctl.d/net_ipv4_conf_default_secure_redirects.conf
+net.ipv4.conf.default.secure_redirects = 0

--- a/data/overlayfiles/pcs-hardening-sap/etc/sysctl.d/net_ipv6_conf_all_accept_ra.conf
+++ b/data/overlayfiles/pcs-hardening-sap/etc/sysctl.d/net_ipv6_conf_all_accept_ra.conf
@@ -1,0 +1,2 @@
+# Per CCE-92473-8: Set net.ipv6.conf.all.accept_ra = 0 in /etc/sysctl.d/net_ipv6_conf_all_accept_ra.conf
+net.ipv6.conf.all.accept_ra = 0

--- a/data/overlayfiles/pcs-hardening-sap/etc/sysctl.d/net_ipv6_conf_all_accept_source_route.conf
+++ b/data/overlayfiles/pcs-hardening-sap/etc/sysctl.d/net_ipv6_conf_all_accept_source_route.conf
@@ -1,0 +1,2 @@
+# Per CCE-85649-2: Set net.ipv6.conf.all.accept_source_route = 0 in /etc/sysctl.d/net_ipv6_conf_all_accept_source_route.conf
+net.ipv6.conf.all.accept_source_route = 0

--- a/data/overlayfiles/pcs-hardening-sap/etc/sysctl.d/net_ipv6_conf_all_forwarding.conf
+++ b/data/overlayfiles/pcs-hardening-sap/etc/sysctl.d/net_ipv6_conf_all_forwarding.conf
@@ -1,0 +1,2 @@
+# Per CCE-85713-6: Set net.ipv6.conf.all.forwarding = 0 in /etc/sysctl.d/net_ipv6_conf_all_forwarding.conf
+net.ipv6.conf.all.forwarding = 0

--- a/data/overlayfiles/pcs-hardening-sap/etc/sysctl.d/net_ipv6_conf_default_accept_ra.conf
+++ b/data/overlayfiles/pcs-hardening-sap/etc/sysctl.d/net_ipv6_conf_default_accept_ra.conf
@@ -1,0 +1,2 @@
+# Per CCE-92474-6: Set net.ipv6.conf.default.accept_ra = 0 in /etc/sysctl.d/net_ipv6_conf_default_accept_ra.conf
+net.ipv6.conf.default.accept_ra = 0

--- a/data/overlayfiles/pcs-hardening-sap/etc/sysctl.d/net_ipv6_conf_default_accept_source_route.conf
+++ b/data/overlayfiles/pcs-hardening-sap/etc/sysctl.d/net_ipv6_conf_default_accept_source_route.conf
@@ -1,0 +1,2 @@
+# Per CCE-85653-4: Set net.ipv6.conf.default.accept_source_route = 0 in /etc/sysctl.d/net_ipv6_conf_default_accept_source_route.conf
+net.ipv6.conf.default.accept_source_route = 0

--- a/data/products/sap/hardened/sle15/config.yaml
+++ b/data/products/sap/hardened/sle15/config.yaml
@@ -4,6 +4,8 @@ config:
       - path: /etc/os-release
         append: True
         content: VARIANT_ID="sles-sap-hardened"
+setup:
   scripts:
     hardened-config:
+      - pcs-hardening-workarounds
       - pcs-sap-hardening

--- a/data/products/sap/hardened/sle15/overlayfiles.yaml
+++ b/data/products/sap/hardened/sle15/overlayfiles.yaml
@@ -1,0 +1,4 @@
+archive:
+  _namespace_sap_hardened:
+    _include_overlays:
+      - pcs-hardening-sap

--- a/data/products/sles/hardened/sle15/config.yaml
+++ b/data/products/sles/hardened/sle15/config.yaml
@@ -4,6 +4,8 @@ config:
       - path: /etc/os-release
         append: True
         content: VARIANT_ID="sles-hardened"
+setup:
   scripts:
     hardened-config:
+      - pcs-hardening-workarounds
       - pcs-hardening

--- a/data/scripts/pcs-hardening-workarounds.sh
+++ b/data/scripts/pcs-hardening-workarounds.sh
@@ -1,0 +1,22 @@
+# NOTE: rules that need running systemd do not work in chroot, disable
+# them until there is an upstream solution.
+# NOTE: rule pam_disable_automatic_configuration uses a bash input redirection
+# type that required /proc which is not availble in kiwi's create step.
+rules_to_disable="\
+xccdf_org.ssgproject.content_rule_ensure_logrotate_activated
+xccdf_org.ssgproject.content_rule_service_firewalld_enabled
+xccdf_org.ssgproject.content_rule_pam_disable_automatic_configuration"
+ssg_file="/usr/share/xml/scap/ssg/content/ssg-sle15-ds.xml"
+
+for rule in $rules_to_disable ; do
+    echo "disable hardening rule $rule"
+    sed -i -e "/$rule/ s/selected=\"true\"/selected=\"false\"/" $ssg_file
+done
+
+# run pam_disable_automatic_configuration remediation directly, to
+# mitigate disabling of the rule
+find /etc/pam.d/ -type l -iname "common-*" -print0 | \
+while IFS= read -r -d '' link; do
+    target=$(readlink -f "$link")
+    cp -p --remove-destination "$target" "$link"
+done

--- a/data/scripts/pcs-hardening-workarounds.sh
+++ b/data/scripts/pcs-hardening-workarounds.sh
@@ -2,10 +2,12 @@
 # them until there is an upstream solution.
 # NOTE: rule pam_disable_automatic_configuration uses a bash input redirection
 # type that required /proc which is not availble in kiwi's create step.
+# NOTE: disable any potential sysctl rules, they do not work properly in chroot.
 rules_to_disable="\
 xccdf_org.ssgproject.content_rule_ensure_logrotate_activated
 xccdf_org.ssgproject.content_rule_service_firewalld_enabled
-xccdf_org.ssgproject.content_rule_pam_disable_automatic_configuration"
+xccdf_org.ssgproject.content_rule_pam_disable_automatic_configuration
+xccdf_org.ssgproject.content_rule_.*sysctl"
 ssg_file="/usr/share/xml/scap/ssg/content/ssg-sle15-ds.xml"
 
 for rule in $rules_to_disable ; do

--- a/data/scripts/pcs-hardening.sh
+++ b/data/scripts/pcs-hardening.sh
@@ -1,5 +1,6 @@
 # run image hardening script
-echo "run oscap -profile pcs-hardening"
+echo "run oscap --profile pcs-hardening"
 oscap xccdf eval --remediate --profile pcs-hardening /usr/share/xml/scap/ssg/content/ssg-sle15-ds.xml || {
     echo "!!!FAILED: --profile pcs-hardening"
+    /bin/false
 }

--- a/data/scripts/pcs-sap-hardening.sh
+++ b/data/scripts/pcs-sap-hardening.sh
@@ -53,11 +53,9 @@ sshd_use_strong_kex \
 # sysctl_net_ipv4_conf_default_send_redirects
 # sysctl_net_ipv4_ip_forward
 
-# remediate selected rules
 for RULE in ${RULES_FROM_CIS}; do
-    echo "run oscap -profile cis_server_l ${RULE}"
-    oscap xccdf eval --remediate --profile cis_server_l1 --rule xccdf_org.ssgproject.content_rule_${RULE} $ssg_file || {
-        echo "!!!FAILED: ${RULE}"
-        /bin/false
-    }
+    RULE_ARGS="$RULE_ARGS --rule xccdf_org.ssgproject.content_rule_$RULE"
 done
+
+# remediate selected rules
+oscap xccdf eval --remediate $RULE_ARGS $ssg_file

--- a/data/scripts/pcs-sap-hardening.sh
+++ b/data/scripts/pcs-sap-hardening.sh
@@ -1,7 +1,10 @@
 # run sap image hardening script
-echo "run oscap -profile pcs-hardening-sap"
-oscap xccdf eval --remediate --profile pcs-hardening-sap /usr/share/xml/scap/ssg/content/ssg-sle15-ds.xml || {
+ssg_file="/usr/share/xml/scap/ssg/content/ssg-sle15-ds.xml"
+
+echo "run oscap --profile pcs-hardening-sap"
+oscap xccdf eval --remediate --profile pcs-hardening-sap $ssg_file || {
     echo "!!!FAILED: --profile pcs-hardening-sap"
+    /bin/false
 }
 
 RULES_FROM_CIS=" \
@@ -13,27 +16,9 @@ file_permissions_home_directories \
 rsyslog_files_permissions \
 journald_forward_to_syslog \
 rsyslog_remote_loghost \
-sysctl_net_ipv6_conf_all_accept_ra \
-sysctl_net_ipv6_conf_all_accept_source_route \
-sysctl_net_ipv6_conf_all_forwarding \
-sysctl_net_ipv6_conf_default_accept_ra \
-sysctl_net_ipv6_conf_default_accept_source_route \
-sysctl_net_ipv4_conf_all_log_martians \
-sysctl_net_ipv4_conf_all_rp_filter \
-sysctl_net_ipv4_conf_all_secure_redirects \
-sysctl_net_ipv4_conf_default_log_martians \
-sysctl_net_ipv4_conf_default_rp_filter \
-sysctl_net_ipv4_conf_default_secure_redirects \
-sysctl_net_ipv4_icmp_ignore_bogus_error_responses \
-sysctl_net_ipv4_tcp_syncookies \
-sysctl_net_ipv4_conf_all_send_redirects \
-sysctl_net_ipv4_conf_default_send_redirects \
-sysctl_net_ipv4_ip_forward \
 package_nftables_removed \
 permissions_local_var_log \
 mount_option_dev_shm_noexec \
-sysctl_fs_suid_dumpable \
-sysctl_kernel_randomize_va_space \
 file_at_deny_not_exist \
 file_cron_deny_not_exist \
 package_rpcbind_removed \
@@ -46,11 +31,33 @@ sshd_do_not_permit_user_env \
 sshd_set_max_auth_tries \
 sshd_use_strong_kex \
 "
+# NOTE: the following were disabled because they try to read from /proc/sys
+# and potentially call sysctl which does not work or make sense in chroot.
+#
+# sysctl_fs_suid_dumpable
+# sysctl_kernel_randomize_va_space
+# sysctl_net_ipv6_conf_all_accept_ra
+# sysctl_net_ipv6_conf_all_accept_source_route
+# sysctl_net_ipv6_conf_all_forwarding
+# sysctl_net_ipv6_conf_default_accept_ra
+# sysctl_net_ipv6_conf_default_accept_source_route
+# sysctl_net_ipv4_conf_all_log_martians
+# sysctl_net_ipv4_conf_all_rp_filter
+# sysctl_net_ipv4_conf_all_secure_redirects
+# sysctl_net_ipv4_conf_default_log_martians
+# sysctl_net_ipv4_conf_default_rp_filter
+# sysctl_net_ipv4_conf_default_secure_redirects
+# sysctl_net_ipv4_icmp_ignore_bogus_error_responses
+# sysctl_net_ipv4_tcp_syncookies
+# sysctl_net_ipv4_conf_all_send_redirects
+# sysctl_net_ipv4_conf_default_send_redirects
+# sysctl_net_ipv4_ip_forward
 
 # remediate selected rules
 for RULE in ${RULES_FROM_CIS}; do
     echo "run oscap -profile cis_server_l ${RULE}"
-    oscap xccdf eval --remediate --profile cis_server_l1 --rule xccdf_org.ssgproject.content_rule_${RULE}  /usr/share/xml/scap/ssg/content/ssg-sle15-ds.xml || {
-	echo "!!!FAILED: ${RULE}"
-	}
+    oscap xccdf eval --remediate --profile cis_server_l1 --rule xccdf_org.ssgproject.content_rule_${RULE} $ssg_file || {
+        echo "!!!FAILED: ${RULE}"
+        /bin/false
+    }
 done

--- a/images/cross-cloud/sles-sap/byos/15-sp4-hardened/setup.yaml
+++ b/images/cross-cloud/sles-sap/byos/15-sp4-hardened/setup.yaml
@@ -1,0 +1,3 @@
+setup:
+  - _include:
+      - products/sap

--- a/images/cross-cloud/sles-sap/byos/15-sp5-hardened/setup.yaml
+++ b/images/cross-cloud/sles-sap/byos/15-sp5-hardened/setup.yaml
@@ -1,0 +1,3 @@
+setup:
+  - _include:
+      - products/sap

--- a/images/cross-cloud/sles-sap/ondemand/15-sp4-hardened/setup.yaml
+++ b/images/cross-cloud/sles-sap/ondemand/15-sp4-hardened/setup.yaml
@@ -1,0 +1,3 @@
+setup:
+  - _include:
+      - products/sap

--- a/images/cross-cloud/sles-sap/ondemand/15-sp5-hardened/setup.yaml
+++ b/images/cross-cloud/sles-sap/ondemand/15-sp5-hardened/setup.yaml
@@ -1,0 +1,3 @@
+setup:
+  - _include:
+      - products/sap

--- a/images/cross-cloud/sles/byos/15-sp4-hardened/setup.yaml
+++ b/images/cross-cloud/sles/byos/15-sp4-hardened/setup.yaml
@@ -1,0 +1,3 @@
+setup:
+  - _include:
+      - products/sles

--- a/images/cross-cloud/sles/byos/15-sp5-hardened/setup.yaml
+++ b/images/cross-cloud/sles/byos/15-sp5-hardened/setup.yaml
@@ -1,0 +1,3 @@
+setup:
+  - _include:
+      - products/sles


### PR DESCRIPTION
This moves the hardening from config.sh to images.sh so it is executed last. Also disables rules that need running systemd or require /proc, and adds remediation for the disabled rules.