### PR TITLE
PCS SAP hardening fixes

### DIFF
--- a/data/scripts/pcs-hardening-workarounds.sh
+++ b/data/scripts/pcs-hardening-workarounds.sh
@@ -1,13 +1,39 @@
-# NOTE: rules that need running systemd do not work in chroot, disable
+# NOTE for disabled rules:
+#
+# rules that need running systemd do not work in chroot, disable
 # them until there is an upstream solution.
-# NOTE: rule pam_disable_automatic_configuration uses a bash input redirection
+#
+# rule pam_disable_automatic_configuration uses a bash input redirection
 # type that required /proc which is not availble in kiwi's create step.
-# NOTE: disable any potential sysctl rules, they do not work properly in chroot.
+#
+# file_permissions_backup_etc_shadow remediation is pointless, useradd
+# creates new backup with standard permissions
+#
+# permissions_local_var_log requires files in /var/log to be not world
+# readable, which is hard to enforce.
+#
+# xccdf_org.ssgproject.content_rule_accounts_users_home_files_permissions
+# requires all files in user home trees to restrict access. Not enforcable.
+#
+# disable any potential sysctl rules, they do not work properly in chroot.
+#
+# disable the following rules proactively, as they were recently added
+# to profile upstream and will break once package is updated
+#
+# accounts_users_home_files_permissions
+# mount_option_dev_shm_noexec
+# permissions_local_var_log
+
 rules_to_disable="\
 xccdf_org.ssgproject.content_rule_ensure_logrotate_activated
 xccdf_org.ssgproject.content_rule_service_firewalld_enabled
 xccdf_org.ssgproject.content_rule_pam_disable_automatic_configuration
+xccdf_org.ssgproject.content_rule_file_permissions_backup_etc_shadow
+xccdf_org.ssgproject.content_rule_accounts_users_home_files_permissions
+xccdf_org.ssgproject.content_rule_mount_option_dev_shm_noexec
+xccdf_org.ssgproject.content_rule_permissions_local_var_log
 xccdf_org.ssgproject.content_rule_.*sysctl"
+
 ssg_file="/usr/share/xml/scap/ssg/content/ssg-sle15-ds.xml"
 
 for rule in $rules_to_disable ; do

--- a/data/scripts/pcs-sap-hardening.sh
+++ b/data/scripts/pcs-sap-hardening.sh
@@ -11,14 +11,11 @@ RULES_FROM_CIS=" \
 banner_etc_issue_net \
 account_disable_post_pw_expiration \
 accounts_set_post_pw_existing \
-accounts_users_home_files_permissions \
 file_permissions_home_directories \
 rsyslog_files_permissions \
 journald_forward_to_syslog \
 rsyslog_remote_loghost \
 package_nftables_removed \
-permissions_local_var_log \
-mount_option_dev_shm_noexec \
 file_at_deny_not_exist \
 file_cron_deny_not_exist \
 package_rpcbind_removed \
@@ -30,7 +27,7 @@ sshd_disable_rhosts \
 sshd_do_not_permit_user_env \
 sshd_set_max_auth_tries \
 sshd_use_strong_kex \
-"
+accounts_umask_etc_login_defs"
 # NOTE: the following were disabled because they try to read from /proc/sys
 # and potentially call sysctl which does not work or make sense in chroot.
 #
@@ -52,6 +49,12 @@ sshd_use_strong_kex \
 # sysctl_net_ipv4_conf_all_send_redirects
 # sysctl_net_ipv4_conf_default_send_redirects
 # sysctl_net_ipv4_ip_forward
+#
+# NOTE: Disabled permissions_local_var_log, some log files will be created world-readable
+#
+# NOTE: Disabled mount_option_dev_shm_noexec because we cannot alter /etc/fstab in build
+#
+# NOTE: Disabled accounts_users_home_files_permissions, not really enforcable
 
 for RULE in ${RULES_FROM_CIS}; do
     RULE_ARGS="$RULE_ARGS --rule xccdf_org.ssgproject.content_rule_$RULE"


### PR DESCRIPTION
This PR  disables the following rules:
- accounts_users_home_files_permissions (even a plain useradd already copies world-readable files from /etc/skel; pointless without further measures)
- rule permissions_local_var_log (there are world-readable logs right after booting; pointless without further measures)
- mount_option_dev_shm_noexec (doesn't work, as kiwi overwrites /etc/fstab after image configuration is done)

Enable rule `accounts_umask_etc_login_defs` (required to enforce rule `file_permissions_home_directories` ).
