### PR TITLE
Addtional packages in SLES 15 SP4 SAPCAL

### DIFF
--- a/data/products/sapcal/sle15/sp4/packages.yaml
+++ b/data/products/sapcal/sle15/sp4/packages.yaml
@@ -1,2 +1,9 @@
 packages:
   _namespace_sapcal_libopenssl_old: Null
+  _namespace_sapcal_extra:
+    package:
+      - xmlstarlet
+      - libcap-progs
+      - openssl
+      - libicu60_2
+      - jq


### PR DESCRIPTION
As requested by Antonia Bahneva-Stoilova from SAP the following packages should be included in the SLES 15 SP4 SAPCAL images:

- xmlstarlet
- libcap-progs
- openssl
- libicu60_2
- jq