### PR TITLE
Include supportutils-plugin-salt

### DIFF
--- a/data/products/suse-manager/server/sle15/packages.yaml
+++ b/data/products/suse-manager/server/sle15/packages.yaml
@@ -6,6 +6,8 @@ packages:
       - patterns-suma_server
       - salt-minion
       - spacecmd
+      - supportutils-plugin-salt
+      - supportutils-plugin-susemanager
       - susemanager-cloud-setup-server
       - release-notes-sles
   _namespace_manager_server_release:


### PR DESCRIPTION
Include package supportutils-plugin-salt in SUSE Manager Server.
Add package supportutils-plugin-susemanager explicitly to SUSE Manager Server.