### PR TITLE
Switch from SUSEConnect to suseconnect-ng

### DIFF
--- a/data/base/common/sle15/packages.yaml
+++ b/data/base/common/sle15/packages.yaml
@@ -29,6 +29,9 @@ packages:
   _namespace_common_rpm:
     package:
       - rpm
+  _namespace_common_suse_connect:
+    package:
+      - SUSEConnect
   _namespace_common_zypper_migration:
     package:
       - zypper-migration-plugin

--- a/data/base/common/sle15/sp1/packages.yaml
+++ b/data/base/common/sle15/sp1/packages.yaml
@@ -1,0 +1,5 @@
+packages:
+  _namespace_common_suse_connect:
+    package:
+      - suseconnect-ng
+  _namespace_common_zypper_migration: Null

--- a/data/base/common/sle15/sp4/packages.yaml
+++ b/data/base/common/sle15/sp4/packages.yaml
@@ -1,2 +1,0 @@
-packages:
-  _namespace_common_zypper_migration: Null

--- a/data/products/sle-micro/packages.yaml
+++ b/data/products/sle-micro/packages.yaml
@@ -49,6 +49,3 @@ packages:
     package:
       - cockpit-wicked
       - wicked
-  _namespace_suseconnect:
-    package:
-      - suseconnect-ng

--- a/data/products/sle15/defaults.yaml
+++ b/data/products/sle15/defaults.yaml
@@ -3,9 +3,6 @@ archive:
     _include_overlays:
       - motd-default
 packages:
-  _namespace_suseconnect:
-    package:
-      - SUSEConnect
   _namespace_yast2_schema:
     package:
       - yast2-schema

--- a/data/products/sle15/sp4/defaults.yaml
+++ b/data/products/sle15/sp4/defaults.yaml
@@ -1,7 +1,4 @@
 packages:
-  _namespace_suseconnect:
-    package:
-      - suseconnect-ng
   _namespace_yast2_schema:
     package:
       - yast2-schema-default


### PR DESCRIPTION
Use suseconnect-ng instead of SUSEConnect in 15 SP1+. Drop zypper-migration-plugin from 15 SP1+.