### PR TITLE
SLE Micro minor fixes

### DIFF
--- a/data/base/common/sle15/config.yaml
+++ b/data/base/common/sle15/config.yaml
@@ -22,13 +22,6 @@ config:
           CONSOLE_ENCODING="UTF-8"
           CONSOLE_FONT="lat9w-16.psfu"
           CONSOLE_SCREENMAP="trivial"
-      - path: /etc/zypp/locks
-        append: True
-        content: |-
-          type: package
-          match_type: glob
-          case_sensitive: on
-          solvable_name: plymouth*
   services:
     common-services:
       - boot.device-mapper

--- a/data/base/sle/sle15/config.yaml
+++ b/data/base/sle/sle15/config.yaml
@@ -1,6 +1,6 @@
 config:
   files:
-    chost-files-plymouth-lock:
+    sle-files-plymouth-lock:
       - path: /etc/zypp/locks
         append: True
         content: |-
@@ -8,11 +8,3 @@ config:
           match_type: glob
           case_sensitive: on
           solvable_name: plymouth*
-  scripts:
-    chost-scripts:
-      - chost-add-variant
-  services:
-    chost-services:
-      - docker
-    chost-docker-img-store:
-      - docker-img-store-setup

--- a/data/products/sle-micro/5.3/config.yaml
+++ b/data/products/sle-micro/5.3/config.yaml
@@ -1,0 +1,3 @@
+config:
+  sysconfig:
+    sle-micro-sysconfig: Null

--- a/data/products/sle-micro/config.yaml
+++ b/data/products/sle-micro/config.yaml
@@ -16,7 +16,7 @@ config:
       - boot.device-mapper
       - docker
   sysconfig:
-    sle-micro-sysconig:
+    sle-micro-sysconfig:
       - file: /etc/sysconfig/network/config
         name: WICKED_DEBUG
         value: "ifconfig,dhcp,autoip,ipv4,ipv6"


### PR DESCRIPTION
This removes a couple of unused/unnecessary settings in SLE Micro and also fixes a typo. Partly addresses https://github.com/SUSE-Enceladus/keg-recipes/issues/245.