### PR TITLE
Re-add plymouth zypp lock to ECS module

### DIFF
--- a/data/csp/ec2/settings/ecs/sle15/config.yaml
+++ b/data/csp/ec2/settings/ecs/sle15/config.yaml
@@ -1,4 +1,13 @@
 config:
+  files:
+    chost-files-plymouth-lock:
+      - path: /etc/zypp/locks
+        append: True
+        content: |-
+          type: package
+          match_type: glob
+          case_sensitive: on
+          solvable_name: plymouth*
   services:
     ecs-services:
       - amazon-ecs


### PR DESCRIPTION
This was removed from `base/common` to `base/sle` in order to drop it from SLE Micro, and hence needs to be re-added to the ECS module to include it in ECS images.