### PR TITLE
Fall back to auto IP if DHCP fails

### DIFF
--- a/data/overlayfiles/sysconfig-network-cloud-netconfig/etc/sysconfig/network/ifcfg-eth0
+++ b/data/overlayfiles/sysconfig-network-cloud-netconfig/etc/sysconfig/network/ifcfg-eth0
@@ -1,3 +1,3 @@
-BOOTPROTO='dhcp'
+BOOTPROTO='dhcp+autoip'
 STARTMODE='auto'
 CLOUD_NETCONFIG_MANAGE='yes'

--- a/data/overlayfiles/sysconfig-network-plain/etc/sysconfig/network/ifcfg-eth0
+++ b/data/overlayfiles/sysconfig-network-plain/etc/sysconfig/network/ifcfg-eth0
@@ -1,2 +1,2 @@
-BOOTPROTO='dhcp'
+BOOTPROTO='dhcp+autoip'
 STARTMODE='auto'


### PR DESCRIPTION
Fall back to locally assigned link-local IP address in case DHCP fails. This helps work around the issue that in EC2, instances in IPv6-only subnet do not have access to IMDS IPv6 endpoints by default.