### PR TITLE
Include all base/sle config modules

### DIFF
--- a/images/single-cloud/azure-li/content.yaml
+++ b/images/single-cloud/azure-li/content.yaml
@@ -10,6 +10,7 @@ image:
   preferences:
     - _include:
         - base/common
+        - base/sle
     - _attributes:
         profiles: [Devel]
       _include:
@@ -33,11 +34,13 @@ image:
 config:
   - _include:
       - base/common
+      - base/sle
       - csp/azure-baremetal/li
       - products/sap
 archive:
   - name: root.tar.gz
     _include:
       - base/common
+      - base/sle
       - csp/azure-baremetal/li
       - products/sap

--- a/images/single-cloud/azure-vli/content.yaml
+++ b/images/single-cloud/azure-vli/content.yaml
@@ -10,6 +10,7 @@ image:
   preferences:
     - _include:
         - base/common
+        - base/sle
     - _attributes:
         profiles: [Devel]
       _include:
@@ -33,11 +34,13 @@ image:
 config:
   - _include:
       - base/common
+      - base/sle
       - csp/azure-baremetal/vli
       - products/sap
 archive:
   - name: root.tar.gz
     _include:
       - base/common
+      - base/sle
       - csp/azure-baremetal/vli
       - products/sap


### PR DESCRIPTION
Include all config modules from base/sle in Azure LI/VLI, not just the package selection. Fixes missing zypp lock for plymouth.