### PR TITLE
Use systemd-sysvcompat in SLE 15 SP6

### DIFF
--- a/data/base/sle/sle15/packages.yaml
+++ b/data/base/sle/sle15/packages.yaml
@@ -55,7 +55,6 @@ packages:
       - strace
       - supportutils-plugin-suse-public-cloud
       - system-user-mail
-      - systemd-sysvinit
       - tcpd
       - tcpdump
       - tcsh
@@ -120,3 +119,6 @@ packages:
   _namespace_sle_cnf:
     package:
       - command-not-found
+  _namespace_sle_sysvcompat:
+    package:
+      - systemd-sysvinit

--- a/data/base/sle/sle15/sp6/packages.yaml
+++ b/data/base/sle/sle15/sp6/packages.yaml
@@ -1,0 +1,4 @@
+packages:
+  _namespace_sle_sysvcompat:
+    package:
+      - systemd-sysvcompat


### PR DESCRIPTION
Use systemd-sysvcompat in SLE 15 SP6 instead of systemd-sysvinit (package rename).