### PR TITLE
Add Azure Fence Agent dependencies (bsc#1210019)

### DIFF
--- a/data/products/sap/sle12/packages.yaml
+++ b/data/products/sap/sle12/packages.yaml
@@ -29,6 +29,8 @@ packages:
       - patterns-ha-ha_sles
       - patterns-sles-base
       - patterns-sles-sap_server
+      - python-azure-identity
+      - python-azure-mgmt-compute
       - release-notes-sles-for-sap
       - SAPHanaSR
       - SAPHanaSR-doc


### PR DESCRIPTION
Add packages python-azure-mgmt-compute and python-azure-identity required by the Azure Fence Agent.