### PR TITLE
Fix sle12 azure fence agent deps

### DIFF
--- a/data/csp/azure/settings/sap/sle12/packages.yaml
+++ b/data/csp/azure/settings/sap/sle12/packages.yaml
@@ -1,0 +1,5 @@
+packages:
+  _namespace_azure_sap:
+    package:
+      - python-azure-mgmt-compute
+      - python-azure-identity

--- a/data/products/sap/sle12/packages.yaml
+++ b/data/products/sap/sle12/packages.yaml
@@ -29,8 +29,6 @@ packages:
       - patterns-ha-ha_sles
       - patterns-sles-base
       - patterns-sles-sap_server
-      - python-azure-identity
-      - python-azure-mgmt-compute
       - release-notes-sles-for-sap
       - SAPHanaSR
       - SAPHanaSR-doc

--- a/images/single-cloud/azure/multi-product-12-sp5/content.yaml
+++ b/images/single-cloud/azure/multi-product-12-sp5/content.yaml
@@ -63,7 +63,7 @@ image:
       _include:
         - base/common
         - base/sle
-        - csp/azure
+        - csp/azure/settings/sap
     - _attributes:
         type: image
         profiles:


### PR DESCRIPTION
This reverts the commit that added the Azure fence deps to the SAP module for SLE 12 and adds them for SLE 12 for SAP for Azure only.

This is mostly an out of principle fix as SLE 12 SP5 images are not built from keg-recipes.