### PR TITLE
Switch to suseconnect-ng in SLE 12

### DIFF
--- a/data/base/common/sle12/packages.yaml
+++ b/data/base/common/sle12/packages.yaml
@@ -32,7 +32,7 @@ packages:
       - supportutils
       - supportutils-plugin-suse-public-cloud
       - suse-build-key
-      - SUSEConnect
+      - suseconnect-ng
       - systemd
       - tcpdump
       - timezone

--- a/data/base/sle/sle12/packages.yaml
+++ b/data/base/sle/sle12/packages.yaml
@@ -118,7 +118,6 @@ packages:
       - yp-tools
       - zip
       - zsh
-      - zypper-migration-plugin
   _namespace_sle_module_public_cloud:
     package:
       - sle-module-public-cloud-release


### PR DESCRIPTION
Include package suseconnect-ng instead of SUSEConnect. Drop obsolete package zypper-migration-plugin.