### PR TITLE
Drop package pam_apparmor from hardened SLES

### DIFF
--- a/data/products/sles/hardened/sle15/packages.yaml
+++ b/data/products/sles/hardened/sle15/packages.yaml
@@ -1,4 +1,0 @@
-packages:
-  _namespace_hardened_sle15:
-    package:
-      - pam_apparmor


### PR DESCRIPTION
Drop package pam_apparmor from hardened SLES as it is not used and causes issues with sudo.