### PR TITLE
Change the serial console setting for GCE

### DIFF
--- a/data/csp/gce/sle12/preferences.yaml
+++ b/data/csp/gce/sle12/preferences.yaml
@@ -4,7 +4,7 @@ preferences:
       firmware: efi
       format: gce
       kernelcmdline:
-        console: ttyS0,38400n8
+        console: ttyS0,115200
         dis_ucode_ldr: []
         multipath: "off"
         NON_PERSISTENT_DEVICE_NAMES: 1

--- a/data/csp/gce/sle15/preferences.yaml
+++ b/data/csp/gce/sle15/preferences.yaml
@@ -4,6 +4,6 @@ preferences:
       bootloader_console: serial
       format: gce
       kernelcmdline:
-        console: ttyS0,38400n8
+        console: ttyS0,115200
         dis_ucode_ldr: []
         multipath: "off"


### PR DESCRIPTION
A new instance type is being introduced that requires this new console setting in order to have access to the serial console. Change the value as requested.