### PR TITLE
Use a subvolume for /var

### DIFF
--- a/data/products/sle-micro/preferences.yaml
+++ b/data/products/sle-micro/preferences.yaml
@@ -6,11 +6,6 @@ preferences:
       btrfs_root_is_snapshot: "true"
       btrfs_root_is_readonly_snapshot: "true"
       filesystem: btrfs
-      spare_part: 5G
-      spare_part_mountpoint: /var
-      spare_part_fs: btrfs
-      spare_part_is_last: "true"
-      spare_part_fs_attributes: no-copy-on-write
       kernelcmdline:
         swapaccount: 1
         ip: dhcp
@@ -34,3 +29,6 @@ preferences:
             name: boot/writable
         - _attributes:
             name: usr/local
+        - _attributes:
+            name: var
+            copy_on_write: false


### PR DESCRIPTION
Having var on a spare partition prevents the resizing of the other parts of the filesyztem as those parts will be in the middle of the partition table. Since we have an image size limit of 10GB in the Public Cloud using any space for var and not being able to resize other parts of the file system creates a size problem. Using a subvolum for var eliminates this problem.