### PR TITLE
Fix sub volume preferences for SLE Micro

### DIFF
--- a/data/products/sle-micro/preferences.yaml
+++ b/data/products/sle-micro/preferences.yaml
@@ -31,4 +31,4 @@ preferences:
             name: usr/local
         - _attributes:
             name: var
-            copy_on_write: false
+            copy_on_write: "false"


### PR DESCRIPTION
Boolean values need to be in quotes otherwise they will end up uppercase in `config.kiwi` which kiwi doesn't accept.