### PR TITLE
Set nvme_core.io_timeout=240

### DIFF
--- a/data/csp/azure/settings/sap/sle15/preferences.yaml
+++ b/data/csp/azure/settings/sap/sle15/preferences.yaml
@@ -1,0 +1,5 @@
+preferences:
+  type:
+    _attributes:
+      kernelcmdline:
+        nvme_core.io_timeout: 240


### PR DESCRIPTION
Set kernel parameter nvme_core.io_timeout to 240 in SLES for SAP for Azure (bsc#1220998).