### PR TITLE
Drop 'Enterprise' from SUSE Linux Enterprise Micro 6.0

### DIFF
--- a/images/cross-cloud/sle-micro/byos/6.0/image.yaml
+++ b/images/cross-cloud/sle-micro/byos/6.0/image.yaml
@@ -6,7 +6,7 @@ image-config-comments:
 image:
   _attributes:
     schemaversion: "7.2"
-    name: SLE-Micro-6-0-BYOS
-    displayname: SLE-Micro-6-0-BYOS
+    name: SL-Micro-6-0-BYOS
+    displayname: SL-Micro-6-0-BYOS
   description:
-    specification: SUSE Linux Enterprise Micro 6.0 BYOS guest image
+    specification: SUSE Linux Micro 6.0 BYOS guest image

--- a/images/cross-cloud/sle-micro/ondemand/6.0/image.yaml
+++ b/images/cross-cloud/sle-micro/ondemand/6.0/image.yaml
@@ -6,7 +6,7 @@ image-config-comments:
 image:
   _attributes:
     schemaversion: "7.2"
-    name: SLE-Micro-6-0
-    displayname: SLE-Micro-6-0
+    name: SL-Micro-6-0
+    displayname: SL-Micro-6-0
   description:
-    specification: SUSE Linux Enterprise Micro 6.0 guest image
+    specification: SUSE Linux Micro 6.0 guest image


### PR DESCRIPTION
The image path is still `cross-cloud/sle-micro`. Not sure whether it's worth creating an extra directory.