### PR TITLE
Drop patch from GCE ALP module

### DIFF
--- a/data/csp/gce/alp/packages.yaml
+++ b/data/csp/gce/alp/packages.yaml
@@ -11,11 +11,6 @@ packages:
       - growpart
       - growpart-rootgrow
       - kernel-default
-  _namespace_gce_patch:
-    package:
-      - _comment: bsc#1165960
-        _attributes:
-          name: patch
   _namespace_gce_tools:
     package:
       - python3-gcemetadata


### PR DESCRIPTION
Remove accidentally included patch from GCE ALP package list. The package was removed in the SLE 15 code stream mode with SP2.