### PR TITLE
SL Micro 6.0 fixes

### DIFF
--- a/data/base/common/alp/config.yaml
+++ b/data/base/common/alp/config.yaml
@@ -26,6 +26,7 @@ config:
     common-services:
       - boot.device-mapper
       - haveged
+      - NetworkManager
       - sshd
       - name: boot.efivars
         enable: False

--- a/data/scripts/snapper-microos-config.sh
+++ b/data/scripts/snapper-microos-config.sh
@@ -13,3 +13,18 @@ if [ "${kiwi_btrfs_root_is_snapshot-false}" = 'true' ]; then
         sed -i'' 's/^NUMBER_LIMIT=.*$/NUMBER_LIMIT="2-10"/g' /etc/snapper/configs/root
         sed -i'' 's/^NUMBER_LIMIT_IMPORTANT=.*$/NUMBER_LIMIT_IMPORTANT="4-10"/g' /etc/snapper/configs/root
 fi
+
+# The %post script can't edit /etc/fstab sys due to https://github.com/OSInside/kiwi/issues/945
+# so use the kiwi custom hack
+cat >/etc/fstab.script <<"EOF"
+#!/bin/sh
+set -eux
+
+/usr/sbin/setup-fstab-for-overlayfs
+# If /var is on a different partition than /...
+if [ "$(findmnt -snT / -o SOURCE)" != "$(findmnt -snT /var -o SOURCE)" ]; then
+  # ... set options for autoexpanding /var
+  gawk -i inplace '$2 == "/var" { $4 = $4",x-growpart.grow,x-systemd.growfs" } { print $0 }' /etc/fstab
+fi
+EOF
+chmod a+x /etc/fstab.script


### PR DESCRIPTION
This PR enables NetworkManager service (it appears it isn't on by default).

It also reverts the commit the dropped the fstab setup for auto-expanding /var in case it's on a separate partition, as this also removed setting up overlayfs for /etc.

I can remove the /var specific code as /var is not a separate partition in any of the image definitions, if desired, but it doesn't really do any harm.