### PR TITLE
Fix missing base services and sysconfig settings

### DIFF
--- a/data/products/sle-micro/6.0/config.yaml
+++ b/data/products/sle-micro/6.0/config.yaml
@@ -5,5 +5,7 @@ config:
       - zypp-disable-multiversion
       - zypp-set-excludedocs
       - zypp-set-onlyrequires
-  services: Null
-  sysconfig: Null
+  services:
+    sle-micro-services: Null
+  sysconfig:
+    sle-micro-sysconfig: Null


### PR DESCRIPTION
`config.yaml`  for SL Micro 6.0 accidentally nulled all services and sysconfig settings, not just the one inherited from `products/sle-micro`.