### PR TITLE
Add SUSE Manager Server 5.0 BYOS definition

### DIFF
--- a/data/overlayfiles/motd-manager-server-5-byos/etc/motd
+++ b/data/overlayfiles/motd-manager-server-5-byos/etc/motd
@@ -1,0 +1,22 @@
+SUSE Manager {SUMA_VERSION} Server
+{OS_PRETTY_NAME} {ARCH} (64-bit)
+
+    ____
+  /@    ~-.
+  \/ __ .- |
+   // // @
+
+Before setting up SUSE Manager, please make sure the system's DNS,
+network security, and storage requirements are met.
+Refer to the installation guide of the SUSE Manager documentation for details.
+
+If SUSE Manager has not been set up yet, please execute:
+
+mgradm install podman --image localhost/suse/manager/{SUMA_VERSION}/x86_64/server
+
+{INCLUDES}
+Documentation: https://www.suse.com/documentation/suse_manager/
+BYOS Guide: https://documentation.suse.com/suma/{SUMA_VERSION}/en/suse-manager/specialized-guides/public-cloud-guide/byos/byos-overview.html
+Community: https://forums.rancher.com/c/suse-manager
+
+Have a lot of fun...

--- a/data/products/suse-manager/server/sle15/sp5/config.yaml
+++ b/data/products/suse-manager/server/sle15/sp5/config.yaml
@@ -1,0 +1,4 @@
+config:
+  scripts:
+    suse-manager-podman-load:
+      - suma-podman-load-image

--- a/data/products/suse-manager/server/sle15/sp5/overlayfiles.yaml
+++ b/data/products/suse-manager/server/sle15/sp5/overlayfiles.yaml
@@ -1,0 +1,5 @@
+archive:
+  _namespace_suma_server_motd:
+    _include_overlays:
+      - motd-manager-server-5-byos
+      - motd-addon-byos

--- a/data/products/suse-manager/server/sle15/sp5/packages.yaml
+++ b/data/products/suse-manager/server/sle15/sp5/packages.yaml
@@ -1,0 +1,15 @@
+packages:
+  _namespace_manager_server_base:
+    package:
+      - netavark
+      - mgradm
+      - mgradm-bash-completion
+      - mgrctl
+      - mgrctl-bash-completion
+      - podman
+      - suse-manager-5.0-x86_64-server-image
+  _namespace_manager_server_modules:
+    package:
+      - sle-module-containers-release
+  _namespace_manager_server_deps: Null
+  _namespace_manager_server_monitoring: Null

--- a/data/scripts/suma-podman-load-image.sh
+++ b/data/scripts/suma-podman-load-image.sh
@@ -1,0 +1,9 @@
+img_dir=/usr/share/suse-docker-images/native
+img_name="localhost/$(jq -c '.["image"]["name"]' <  ${img_dir}/suse-manager-*.metadata | tr -d '"\n' | tr - /)"
+tags=$(jq -c '.["image"]["tags"]' <  ${img_dir}/suse-manager-*.metadata | tr -d '[]"\n' | tr ',' ' ')
+podman load -i /usr/share/suse-docker-images/native/suse-manager-*-x86_64-server
+for tag in $tags ; do
+    test "$tag" = "latest" && continue
+    podman tag ${img_name}:latest ${img_name}:$tag
+done
+zypper --non-interactive rm suse-manager-\*-x86_64-server-image

--- a/images/cross-cloud/suse-manager/server/5.0/image.yaml
+++ b/images/cross-cloud/suse-manager/server/5.0/image.yaml
@@ -1,0 +1,14 @@
+include-paths:
+  - sle15/sp1
+  - sle15/sp2
+  - sle15/sp3
+  - sle15/sp4
+  - sle15/sp5
+  - "5.0"
+image:
+  _attributes:
+    schemaversion: "7.2"
+    name: SLES15-SP5-Manager-Server-5-0-BYOS
+    displayname: SLES15-SP5-Manager-Server-5-0-BYOS
+  description:
+    specification: "SUSE Manager Server 5.0 BYOS guest image"


### PR DESCRIPTION
This adds the image definition and data for SUMA Server 5.0 BYOS. The image build loads the suma container file from the rpm into the podman registry and deletes the rpm afterwards.