### PR TITLE
Re-add SLE Micro 5.x kernel parametes

### DIFF
--- a/data/products/sle-micro/5.1/packages.yaml
+++ b/data/products/sle-micro/5.1/packages.yaml
@@ -1,4 +1,0 @@
-packages:
-  _namespace_sle_micro_cockpit_dashboard:
-    package:
-      - cockpit-dashboard

--- a/data/products/sle-micro/5.1/preferences.yaml
+++ b/data/products/sle-micro/5.1/preferences.yaml
@@ -1,7 +1,0 @@
-preferences:
-  type:
-    _attributes:
-      kernelcmdline:
-        ip: dhcp
-        rd.neednet: 1
-        "\\$ignition_firstboot": []

--- a/data/products/sle-micro/5.3/preferences.yaml
+++ b/data/products/sle-micro/5.3/preferences.yaml
@@ -2,4 +2,7 @@ preferences:
   type:
     _attributes:
       kernelcmdline:
+        ip: dhcp
+        rd.neednet: 1
+        "\\$ignition_firstboot": []
         swapaccount: 1


### PR DESCRIPTION
Re-add accidentally removed ignition specific kernel parameters to SLE Micro 5.x.

I had moved them from the parent dir to the unused `5.1` sub directory when adding SL Micro 6 data, hence removing them from the image descriptions. This PR moves them into `5.3` and also removes the unused `5.1` directory.