### PR TITLE
Use new podman-load-images script

### DIFF
--- a/data/products/suse-manager/server/sle15/sp5/config.yaml
+++ b/data/products/suse-manager/server/sle15/sp5/config.yaml
@@ -1,4 +1,4 @@
 config:
   scripts:
     suse-manager-podman-load:
-      - suma-podman-load-image
+      - podman-load-images


### PR DESCRIPTION
Use new podman-load-images script to load SUSE Manager Server container image during build.