### PR TITLE
Do not use ignition and afterburn

### DIFF
--- a/data/csp/azure/settings/suma-server/sle15/sp5/config.yaml
+++ b/data/csp/azure/settings/suma-server/sle15/sp5/config.yaml
@@ -1,0 +1,8 @@
+config:
+  scripts:
+    azure-default-kernel-log-level: Null
+  services:
+    azure-regionsrv-timer:
+      - regionsrv-enabler-azure.timer
+  sysconfig:
+    azure-set-hostname: Null

--- a/data/products/suse-manager/sle15/sp5/config.yaml
+++ b/data/products/suse-manager/sle15/sp5/config.yaml
@@ -1,0 +1,10 @@
+config:
+  scripts:
+    sle-micro-scripts:
+      - chost-strip-image
+      - microos-add-variant
+      - selinux-enforce
+      - snapper-microos-config
+      - zypp-disable-multiversion
+      - zypp-set-excludedocs
+      - zypp-set-onlyrequires

--- a/data/products/suse-manager/sle15/sp5/packages.yaml
+++ b/data/products/suse-manager/sle15/sp5/packages.yaml
@@ -1,0 +1,48 @@
+packages:
+  _namespace_sle_micro:
+    namedCollection:
+      - _attributes:
+          name: microos-salt_minion
+    package:
+      - btrfsmaintenance
+      - btrfsprogs
+      - ca-certificates
+      - ca-certificates-mozilla
+      - cockpit-system
+      - cockpit-ws
+      - cockpit
+      - conntrack-tools
+      - container-selinux
+      - cracklib-dict-small
+      - distribution-release
+      - docker
+      - glibc-locale-base
+      - issue-generator
+      - health-checker
+      - health-checker-plugins-MicroOS
+      - hwinfo
+      - less
+      - libnss_usrfiles2
+      - microos-tools
+      - NetworkManager
+      - NetworkManager-branding-SLE
+      - parted
+      - pkgconfig
+      - policycoreutils
+      - rebootmgr
+      - rollback-helper
+      - selinux-policy-targeted
+      - selinux-tools
+      - supportutils-plugin-suse-public-cloud
+      - systemd-presets-branding-SMO
+      - systemd-default-settings-branding-SLE-Micro
+      - SUSE-MicroOS-release
+      - toolbox
+      - transactional-update
+      - transactional-update-zypp-config
+      - vim-small
+      - yast2-logs
+      - zypper-needs-restarting
+  _namespace_yast2_schema:
+    package:
+      - yast2-schema-micro

--- a/data/products/suse-manager/sle15/sp5/preferences.yaml
+++ b/data/products/suse-manager/sle15/sp5/preferences.yaml
@@ -1,0 +1,30 @@
+preferences:
+  type:
+    _attributes:
+      bootpartsize: Null
+      btrfs_quota_groups: "true"
+      btrfs_root_is_snapshot: "true"
+      btrfs_root_is_readonly_snapshot: "true"
+      filesystem: btrfs
+      kernelcmdline:
+        security: "selinux"
+        selinux: 1
+    systemdisk:
+      volume:
+        - _attributes:
+            name: home
+        - _attributes:
+            name: root
+        - _attributes:
+            name: opt
+        - _attributes:
+            name: srv
+        - _attributes:
+            name: boot/grub2/i386-pc
+        - _attributes:
+            name: boot/writable
+        - _attributes:
+            name: usr/local
+        - _attributes:
+            name: var
+            copy_on_write: "false"

--- a/images/cross-cloud/suse-manager/server/5.0/content.yaml
+++ b/images/cross-cloud/suse-manager/server/5.0/content.yaml
@@ -16,18 +16,18 @@ image:
     - _attributes:
         profiles: [Azure]
       _include:
-        - csp/azure/settings/micro
-        - products/sle-micro
+        - csp/azure/settings/suma-server
+        - products/suse-manager/server
     - _attributes:
         profiles: [EC2]
       _include:
-        - csp/ec2/settings/micro
-        - products/sle-micro
+        - csp/ec2/settings/suma-server
+        - products/suse-manager/server
     - _attributes:
         profiles: [GCE]
       _include:
-        - csp/gce/settings/micro
-        - products/sle-micro
+        - csp/gce/settings/suma-server
+        - products/suse-manager/server
   packages:
     - _attributes:
        type: bootstrap
@@ -37,13 +37,12 @@ image:
         type: image
       _include:
         - base/common
-        - products/sle-micro
         - products/suse-manager/server
     - _attributes:
         type: image
         profiles: [Azure]
       _include:
-        - csp/azure/settings/micro
+        - csp/azure/settings/suma-server
       archive:
         - _attributes:
             name: azure.tar.gz
@@ -51,7 +50,7 @@ image:
         type: image
         profiles: [EC2]
       _include:
-        - csp/ec2/settings/micro
+        - csp/ec2/settings/suma-server
       archive:
         - _attributes:
             name: ec2.tar.gz
@@ -59,36 +58,34 @@ image:
         type: image
         profiles: [GCE]
       _include:
-        - csp/gce/settings/micro
+        - csp/gce/settings/suma-server
       archive:
         - _attributes:
             name: gce.tar.gz
 config:
   - _include:
       - base/common
-      - products/sle-micro
       - products/suse-manager/server
   - profiles: [Azure]
     _include:
-      - csp/azure/settings/micro
+      - csp/azure/settings/suma-server
   - profiles: [EC2]
     _include:
-      - csp/ec2/settings/micro
+      - csp/ec2/settings/suma-server
   - profiles: [GCE]
     _include:
-      - csp/gce/settings/micro
+      - csp/gce/settings/suma-server
 archive:
   - name: root.tar.gz
     _include:
       - base/common
-      - products/sle-micro
       - products/suse-manager/server
   - name: azure.tar.gz
     _include:
-      - csp/azure/settings/micro
+      - csp/azure/settings/suma-server
   - name: ec2.tar.gz
     _include:
-      - csp/ec2/settings/micro
+      - csp/ec2/settings/suma-server
   - name: gce.tar.gz
     _include:
-      - csp/gce/settings/micro
+      - csp/gce/settings/suma-server


### PR DESCRIPTION
Do not use ignition and afterburn but cloud-init, python-azure-agent, and google-guest-agent respectively in SUSE Manager 5.0.