### PR TITLE
SUSE Manager 5.0 dependency fixes

### DIFF
--- a/data/csp/azure/settings/suma-server/sle15/sp5/config.yaml
+++ b/data/csp/azure/settings/suma-server/sle15/sp5/config.yaml
@@ -1,8 +1,5 @@
 config:
   scripts:
     azure-default-kernel-log-level: Null
-  services:
-    azure-regionsrv-timer:
-      - regionsrv-enabler-azure.timer
   sysconfig:
     azure-set-hostname: Null

--- a/data/products/suse-manager/sle15/sp5/packages.yaml
+++ b/data/products/suse-manager/sle15/sp5/packages.yaml
@@ -23,6 +23,7 @@ packages:
       - hwinfo
       - less
       - libnss_usrfiles2
+      - libpwquality-tools
       - microos-tools
       - NetworkManager
       - NetworkManager-branding-SLE


### PR DESCRIPTION
Adds two packages:

- cloud-regionsrv-client-addon-azure (is this wanted?)
- libpwquality-tools (required by cockpit-system via file dependency, which OBS can't resolve)