### PR TITLE
Add aarch64 settings for SUSE Manager 5.0

### DIFF
--- a/data/products/suse-manager/aarch64/preferences.yaml
+++ b/data/products/suse-manager/aarch64/preferences.yaml
@@ -1,0 +1,8 @@
+preferences:
+  type:
+    systemdisk:
+      _namespace_micro_aarch64:
+        volume:
+          - _attributes:
+              name: boot/grub2/arm64-efi
+              mountpoint: boot/grub2/arm64-efi

--- a/data/products/suse-manager/server/sle15/sp5/packages.yaml
+++ b/data/products/suse-manager/server/sle15/sp5/packages.yaml
@@ -8,7 +8,12 @@ packages:
       - mgrctl
       - mgrctl-bash-completion
       - podman
-      - suse-manager-5.0-x86_64-server-image
+      - _attributes:
+          name: suse-manager-5.0-x86_64-server-image
+          arch: x86_64
+      - _attributes:
+          name: suse-manager-5.0-aarch64-server-image
+          arch: aarch64
   _namespace_manager_server_modules:
     package:
       - sle-module-containers-release

--- a/data/products/suse-manager/x86_64/preferences.yaml
+++ b/data/products/suse-manager/x86_64/preferences.yaml
@@ -1,0 +1,8 @@
+preferences:
+  type:
+    systemdisk:
+      _namespace_micro_x86_64:
+        volume:
+          - _attributes:
+              name: boot/grub2/x86_64-efi
+              mountpoint: boot/grub2/x86_64-efi

--- a/images/cross-cloud/suse-manager/server/5.0/content.yaml
+++ b/images/cross-cloud/suse-manager/server/5.0/content.yaml
@@ -15,18 +15,46 @@ image:
         - base/common
     - _attributes:
         profiles: [Azure]
+        arch: x86_64
       _include:
         - csp/azure/settings/suma-server
+        - products/suse-manager/x86_64
+        - products/suse-manager/server
+    - _attributes:
+        profiles: [Azure]
+        arch: aarch64
+      _include:
+        - csp/azure/settings/aarch64
+        - csp/azure/settings/suma-server
+        - products/suse-manager/aarch64
         - products/suse-manager/server
     - _attributes:
         profiles: [EC2]
+        arch: x86_64
       _include:
         - csp/ec2/settings/suma-server
+        - products/suse-manager/x86_64
+        - products/suse-manager/server
+    - _attributes:
+        profiles: [EC2]
+        arch: aarch64
+      _include:
+        - csp/ec2/settings/suma-server
+        - products/suse-manager/aarch64
         - products/suse-manager/server
     - _attributes:
         profiles: [GCE]
+        arch: x86_64
       _include:
         - csp/gce/settings/suma-server
+        - products/suse-manager/x86_64
+        - products/suse-manager/server
+    - _attributes:
+        profiles: [GCE]
+        arch: aarch64
+      _include:
+        - csp/gce/settings/suma-server
+        - products/suse-manager/aarch64
         - products/suse-manager/server
   packages:
     - _attributes:


### PR DESCRIPTION
Add aarch64 specific settings to SUSE Manager 5.0 recipe.
Add missing sub volume boot/grub2/x86_64-efi to SUSE Manager 5.0 x86_64 recipe.