### PR TITLE
Switch to libnfsidmap1

### DIFF
--- a/data/base/sle/sle15/packages.yaml
+++ b/data/base/sle/sle15/packages.yaml
@@ -39,7 +39,6 @@ packages:
       - man-pages
       - mozilla-nss-certs
       - netcat-openbsd
-      - nfsidmap
       - nfs-client
       - nfs-kernel-server
       - nscd
@@ -122,3 +121,6 @@ packages:
   _namespace_sle_sysvcompat:
     package:
       - systemd-sysvinit
+  _namespace_sle_nfsidmap:
+    package:
+      - nfsidmap

--- a/data/base/sle/sle15/sp6/packages.yaml
+++ b/data/base/sle/sle15/sp6/packages.yaml
@@ -2,3 +2,6 @@ packages:
   _namespace_sle_sysvcompat:
     package:
       - systemd-sysvcompat
+  _namespace_sle_nfsidmap:
+    package:
+      - libnfsidmap1


### PR DESCRIPTION
Switch from obsolete package nfsidmap to libnfsidmap1 in SLE 15 SP6.