### PR TITLE
Pattern renaming

### DIFF
--- a/data/base/common/alp/packages.yaml
+++ b/data/base/common/alp/packages.yaml
@@ -1,11 +1,11 @@
 packages:
   _namespace_common_alp:
     namedCollection:
-      - alp_base_transactional
-      - alp_defaults
+      - base_transactional
+      - micro_defaults
     package:
-      - patterns-alp-base-transactional
-      - patterns-alp-defaults
+      - patterns-base-transactional
+      - patterns-micro-defaults
       - ca-certificates
       - glibc-locale-base
       - grub2-branding-SLE


### PR DESCRIPTION
The use of the ALP name has been discontinued. Since pattern names are user visible the alp TLA is being dropped from pattern naming.