### PR TITLE
Fix keytable parameter

### DIFF
--- a/data/base/common/alp/preferences.yaml
+++ b/data/base/common/alp/preferences.yaml
@@ -1,5 +1,5 @@
 preferences:
-  keytable: us.map.gz
+  keytable: us
   locale: en_US
   packagemanager: zypper
   rpm-check-signatures: "false"

--- a/data/base/common/sle15/preferences.yaml
+++ b/data/base/common/sle15/preferences.yaml
@@ -1,5 +1,5 @@
 preferences:
-  keytable: us.map.gz
+  keytable: us
   locale: en_US
   packagemanager: zypper
   rpm-check-signatures: "false"


### PR DESCRIPTION
Use keytable 'us' instead of 'us.map.gz'. The latter fails SLE 15 SP6 builds. Alternatively we could simply drop the parameter, since 'us' is the default anyway.