### PR TITLE
HPC is SLES

### DIFF
--- a/data/products/hpc/sle15/sp6/packages.yaml
+++ b/data/products/hpc/sle15/sp6/packages.yaml
@@ -1,0 +1,4 @@
+packages:
+  _namespace_hpc_release:
+    package:
+      - sles-release


### PR DESCRIPTION
Starting in 15 SP6 SLE HPC is no longer a product, it reverts to it's previous state of being available through a module as part of SLES. The product team is refusing to change the SLE_HPC product release package to reflect that it should identify itself as SLES during registration. Therefore we need to accommodate the change in the image build and use the SLES release package.