### PR TITLE
Add cryptsetup to SLE Micro 5.5

### DIFF
--- a/data/products/sle-micro/5.5/packages.yaml
+++ b/data/products/sle-micro/5.5/packages.yaml
@@ -1,0 +1,5 @@
+packages:
+  _namespace_sle_micro_cryptsetup:
+    package:
+      - cryptsetup
+      - device-mapper


### PR DESCRIPTION
Add packages cryptsetup and device-mapper to SLE Micro 5.5, required by ignition update.