### PR TITLE
Do not use boot partition

### DIFF
--- a/data/csp/azure/settings/micro/alp/preferences.yaml
+++ b/data/csp/azure/settings/micro/alp/preferences.yaml
@@ -1,0 +1,5 @@
+preferences:
+  type:
+    _attributes:
+      bootpartition: Null
+      bootpartsize: Null


### PR DESCRIPTION
Do not use boot partition for SL Micro 6.0 in Azure (bsc#1222719).