### PR TITLE
Add package libnsl1

### DIFF
--- a/data/products/sap/sle15/sp6/packages.yaml
+++ b/data/products/sap/sle15/sp6/packages.yaml
@@ -1,0 +1,4 @@
+packages:
+  _namespace_sap_libnsl1:
+    package:
+      - libnsl1


### PR DESCRIPTION
Add package libnsl1 to SLES for SAP 15 SP6 as required by the SAP HANA client installer (bsc#1223133).