### PR TITLE
Use python 3.11 packages

### DIFF
--- a/data/csp/azure/sle15/sp4/packages.yaml
+++ b/data/csp/azure/sle15/sp4/packages.yaml
@@ -1,0 +1,7 @@
+packages:
+  _namespace_azure_tools:
+    package:
+      - azure-cli
+      - lsscsi
+      - python311-azure-sdk
+      - python3-azuremetadata

--- a/data/csp/ec2/sle15/sp4/packages.yaml
+++ b/data/csp/ec2/sle15/sp4/packages.yaml
@@ -1,0 +1,4 @@
+packages:
+  _namespace_ec2_image_utils:
+    package:
+      - python311-ec2imgutils


### PR DESCRIPTION
Explicitly include python 3.11 versions of ec2imgutils and Azure SDK to avoid build issues.