### PR TITLE
Set schemaversion to 7.2

### DIFF
--- a/images/cross-cloud/suse-manager/proxy/5.0/image.yaml
+++ b/images/cross-cloud/suse-manager/proxy/5.0/image.yaml
@@ -9,7 +9,7 @@ include-paths:
   - "5.5"
 image:
   _attributes:
-    schemaversion: "7.4"
+    schemaversion: "7.2"
     name: SLES15-SP5-Manager-Proxy-5-0-BYOS
     displayname: SLES15-SP5-Manager-Proxy-5-0-BYOS
   description:


### PR DESCRIPTION
Set schemaversion of SUSE Manager Proxy 5.0 image definition to 7.2.

Otherwise kiwi complains about various options being not allowed with image type `vmx`. We might want to consider switching to `oem`.