### PR TITLE
Remove package sle-module-containers-release

### DIFF
--- a/data/products/suse-manager/proxy/sle15/sp5/packages.yaml
+++ b/data/products/suse-manager/proxy/sle15/sp5/packages.yaml
@@ -36,6 +36,4 @@ packages:
       - _attributes:
           name: suse-manager-5.0-aarch64-proxy-tftpd-image
           arch: aarch64
-  _namespace_manager_proxy_modules:
-    package:
-      - sle-module-containers-release
+  _namespace_manager_proxy_modules: Null

--- a/data/products/suse-manager/server/sle15/sp5/packages.yaml
+++ b/data/products/suse-manager/server/sle15/sp5/packages.yaml
@@ -14,8 +14,6 @@ packages:
       - _attributes:
           name: suse-manager-5.0-aarch64-server-image
           arch: aarch64
-  _namespace_manager_server_modules:
-    package:
-      - sle-module-containers-release
+  _namespace_manager_server_modules: Null
   _namespace_manager_server_deps: Null
   _namespace_manager_server_monitoring: Null


### PR DESCRIPTION
Remove package sle-module-containers-release from SUSE Manager 5.0 recipes.