### PR TITLE
Add packages cryptsetup and device-mapper

### DIFF
--- a/data/products/sle-micro/5.3/packages.yaml
+++ b/data/products/sle-micro/5.3/packages.yaml
@@ -6,3 +6,7 @@ packages:
   _namespace_yast2_schema:
     package:
       - yast2-schema-micro
+  _namespace_sle_micro_cryptsetup:
+    package:
+      - cryptsetup
+      - device-mapper

--- a/data/products/sle-micro/5.5/packages.yaml
+++ b/data/products/sle-micro/5.5/packages.yaml
@@ -1,5 +1,0 @@
-packages:
-  _namespace_sle_micro_cryptsetup:
-    package:
-      - cryptsetup
-      - device-mapper


### PR DESCRIPTION
Add packages cryptsetup and device-mapper to SLE Micro 5.3 and 5.4, required for growing root volume (bsc#1224234).