### PR TITLE
Use kiwi-repart to grow root filesystem

### DIFF
--- a/data/overlayfiles/dracut-kiwi-resize/etc/dracut.conf.d/40-kiwi-resize.conf
+++ b/data/overlayfiles/dracut-kiwi-resize/etc/dracut.conf.d/40-kiwi-resize.conf
@@ -1,0 +1,1 @@
+add_dracutmodules+=" kiwi-repart "

--- a/data/products/sle-micro/5.3/overlayfiles.yaml
+++ b/data/products/sle-micro/5.3/overlayfiles.yaml
@@ -1,0 +1,4 @@
+archive:
+  _namespace_sle_micro_kiwi_resize:
+    _include_overlays:
+      - dracut-kiwi-resize

--- a/data/products/sle-micro/5.3/packages.yaml
+++ b/data/products/sle-micro/5.3/packages.yaml
@@ -10,3 +10,6 @@ packages:
     package:
       - cryptsetup
       - device-mapper
+  _namespace_sle_micro_kiwi_resize:
+    package:
+      - dracut-kiwi-oem-repart

--- a/data/products/sle-micro/5.3/preferences.yaml
+++ b/data/products/sle-micro/5.3/preferences.yaml
@@ -1,6 +1,7 @@
 preferences:
   type:
     _attributes:
+      image: oem
       kernelcmdline:
         ip: dhcp
         rd.neednet: 1

--- a/images/cross-cloud/sle-micro/byos/5.3/image.yaml
+++ b/images/cross-cloud/sle-micro/byos/5.3/image.yaml
@@ -6,7 +6,7 @@ include-paths:
   - "5.3"
 image:
   _attributes:
-    schemaversion: "7.2"
+    schemaversion: "7.5"
     name: SLES15-SP4-Micro-5-3-BYOS
     displayname: SLES15-SP4-Micro-5-3-BYOS
   description:

--- a/images/cross-cloud/sle-micro/byos/5.4/image.yaml
+++ b/images/cross-cloud/sle-micro/byos/5.4/image.yaml
@@ -7,7 +7,7 @@ include-paths:
   - "5.4"
 image:
   _attributes:
-    schemaversion: "7.2"
+    schemaversion: "7.5"
     name: SLES15-SP4-Micro-5-4-BYOS
     displayname: SLES15-SP4-Micro-5-4-BYOS
   description:

--- a/images/cross-cloud/sle-micro/byos/5.5/image.yaml
+++ b/images/cross-cloud/sle-micro/byos/5.5/image.yaml
@@ -9,7 +9,7 @@ include-paths:
   - "5.5"
 image:
   _attributes:
-    schemaversion: "7.2"
+    schemaversion: "7.5"
     name: SLES15-SP5-Micro-5-5-BYOS
     displayname: SLES15-SP5-Micro-5-5-BYOS
   description:

--- a/images/cross-cloud/sle-micro/ondemand/5.3/image.yaml
+++ b/images/cross-cloud/sle-micro/ondemand/5.3/image.yaml
@@ -6,7 +6,7 @@ include-paths:
   - "5.3"
 image:
   _attributes:
-    schemaversion: "7.2"
+    schemaversion: "7.5"
     name: SLES15-SP4-Micro-5-3
     displayname: SLES15-SP4-Micro-5-3
   description:

--- a/images/cross-cloud/sle-micro/ondemand/5.4/image.yaml
+++ b/images/cross-cloud/sle-micro/ondemand/5.4/image.yaml
@@ -7,7 +7,7 @@ include-paths:
   - "5.4"
 image:
   _attributes:
-    schemaversion: "7.2"
+    schemaversion: "7.5"
     name: SLES15-SP4-Micro-5-4
     displayname: SLES15-SP4-Micro-5-4
   description:

--- a/images/cross-cloud/sle-micro/ondemand/5.5/image.yaml
+++ b/images/cross-cloud/sle-micro/ondemand/5.5/image.yaml
@@ -9,7 +9,7 @@ include-paths:
   - "5.5"
 image:
   _attributes:
-    schemaversion: "7.2"
+    schemaversion: "7.5"
     name: SLES15-SP5-Micro-5-5
     displayname: SLES15-SP5-Micro-5-5
   description:


### PR DESCRIPTION
Use kiwi-repart to grow root filesystem in SLE Micro 5.x (bsc#1224234).

This changes the image type to `oem` and uses schema version 7.5 for the image description. We might want to consider applying that to all images as this would change the schema version to what kiwi in SLES uses natively.