### PR TITLE
Enable guestregister

### DIFF
--- a/data/products/suse-manager/server/sle15/sp5/config.yaml
+++ b/data/products/suse-manager/server/sle15/sp5/config.yaml
@@ -1,0 +1,4 @@
+config:
+  services:
+    suse-manager-guestregister:
+      - guestregister


### PR DESCRIPTION
Enable guestregister service in SUSE Manager Server 5.0 PAYG (bsc#1226903).