### PR TITLE
Use python-azure-agent-config-server

### DIFF
--- a/data/csp/azure/settings/micro/alp/packages.yaml
+++ b/data/csp/azure/settings/micro/alp/packages.yaml
@@ -1,4 +1,4 @@
 packages:
   _namespace_azure_waagent_config:
     package:
-      - python-azure-agent-config-micro
+      - python-azure-agent-config-server


### PR DESCRIPTION
Use server instead of micro version of the python-azure-agent-config package, as the server version is intended to be used with cloud-init which SLE Micro 6 uses for instance initialization.