### PR TITLE
Drop yast2-saptune from SLES for SAP 15 SP5+

### DIFF
--- a/data/products/sap/sle15/packages.yaml
+++ b/data/products/sap/sle15/packages.yaml
@@ -44,6 +44,8 @@ packages:
       - yast2-sap-ha
       - yast2-sap-scp
       - yast2-sap-scp-prodlist
+  _namespace_sap_yast2_saptune:
+    package:
       - yast2-saptune
   _namespace_sap_release:
     package:

--- a/data/products/sap/sle15/sp5/packages.yaml
+++ b/data/products/sap/sle15/sp5/packages.yaml
@@ -1,0 +1,2 @@
+packages:
+  _namespace_sap_yast2_saptune: Null


### PR DESCRIPTION
`yast2-saptune` was dropped from SP5+.