### PR TITLE
Fix kiwi repart (bsc#1228118 bsc#1228550)

### DIFF
--- a/data/overlayfiles/dracut-kiwi-resize/etc/dracut.conf.d/40-kiwi-resize.conf
+++ b/data/overlayfiles/dracut-kiwi-resize/etc/dracut.conf.d/40-kiwi-resize.conf
@@ -1,1 +1,2 @@
-add_dracutmodules+=" kiwi-repart "
+add_dracutmodules+=" kiwi-repart-profile kiwi-repart "
+install_items+=" /.profile /config.partids"

--- a/data/overlayfiles/dracut-kiwi-resize/usr/lib/dracut/modules.d/89kiwi-repart-profile/module-setup.sh
+++ b/data/overlayfiles/dracut-kiwi-resize/usr/lib/dracut/modules.d/89kiwi-repart-profile/module-setup.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+check() {
+    return 255
+}
+
+depends() {
+    echo rootfs-block dm kiwi-lib
+    return 0
+}
+
+install() {
+    if [[ ! -f /.profile ]]; then
+        cp /.kiwi_profile /.profile
+    fi
+}

--- a/data/products/sle-micro/5.3/config.yaml
+++ b/data/products/sle-micro/5.3/config.yaml
@@ -1,3 +1,8 @@
 config:
   sysconfig:
     sle-micro-sysconfig: Null
+setup:
+  scripts:
+    # Workaround bsc#1228550 bsc#1228118
+    sle-micro-kiwi-profile:
+      - capture-kiwi-profile

--- a/data/scripts/capture-kiwi-profile.sh
+++ b/data/scripts/capture-kiwi-profile.sh
@@ -1,0 +1,1 @@
+env | grep "^kiwi_" > /.kiwi_profile

--- a/images/cross-cloud/sle-micro/byos/content.yaml
+++ b/images/cross-cloud/sle-micro/byos/content.yaml
@@ -74,6 +74,9 @@ config:
   - profiles: [GCE]
     _include:
       - csp/gce/settings/micro
+setup:
+  - _include:
+    - products/sle-micro
 archive:
   - name: root.tar.gz
     _include:

--- a/images/cross-cloud/sle-micro/ondemand/content.yaml
+++ b/images/cross-cloud/sle-micro/ondemand/content.yaml
@@ -75,6 +75,9 @@ config:
   - profiles: [GCE]
     _include:
       - csp/gce/settings/micro
+setup:
+  - _include:
+    - products/sle-micro
 archive:
   - name: root.tar.gz
     _include:


### PR DESCRIPTION
Add /.profile and /config.partids to initrd (required for kiwi-repart).
Add script to capture kiwi profile during build into /.kiwi_profile and dracut module to copy it to /.profile on initrd generation until upstream kiwi fix is available.