### PR TITLE
Add mount config for SLES

### DIFF
--- a/data/products/sle-micro/packages.yaml
+++ b/data/products/sle-micro/packages.yaml
@@ -26,6 +26,7 @@ packages:
       - health-checker-plugins-MicroOS
       - hwinfo
       - less
+      - libcontainers-sles-mounts
       - libnss_usrfiles2
       - microos-tools
       - parted


### PR DESCRIPTION
Add libcontainers-sles-mounts package whcih provides the mount directives for the SCC credentials directories such that containers, primarily SLE BCI can access the repositories from the host.