### PR TITLE
Suport CHOST build for GDC

### DIFF
--- a/data/csp/gdc/sle15/overlayfiles.yaml
+++ b/data/csp/gdc/sle15/overlayfiles.yaml
@@ -1,0 +1,10 @@
+archive:
+  _namespace_gdc_base:
+    _include_overlays:
+      - chrony-gdc-ntp
+      - sysconfig-network-plain1
+      - dracut-xfs
+  _namespace_gdc_cloud_init_cfg:
+    _include_overlays:
+      - cloud-cfg-gdc
+      - cloud-cfg-disable-network-config

--- a/data/csp/gdc/sle15/packages.yaml
+++ b/data/csp/gdc/sle15/packages.yaml
@@ -1,0 +1,4 @@
+packages:
+  _namespace_gdc_init:
+    package:
+      - cloud-init

--- a/data/csp/gdc/sle15/preferences.yaml
+++ b/data/csp/gdc/sle15/preferences.yaml
@@ -1,0 +1,11 @@
+preferences:
+  type:
+    _attributes:
+      firmware: Null
+      format: qcow2
+      vga: normal
+      kernelcmdline:
+        console: ["tty1", "ttyS0"]
+        ci.datasource: NoCloud
+        multipath: "off"
+        NON_PERSISTENT_DEVICE_NAMES: 1

--- a/data/overlayfiles/chrony-gdc-ntp/etc/chrony.d/gdc.conf
+++ b/data/overlayfiles/chrony-gdc-ntp/etc/chrony.d/gdc.conf
@@ -1,0 +1,8 @@
+# GDCH timesource
+server ntp1.org.internal
+server ntp2.org.internal
+server ntp3.org.internal
+server ntp4.org.internal
+server ntp5.org.internal
+server ntp6.org.internal
+

--- a/data/overlayfiles/cloud-cfg-gdc/etc/cloud/cloud.cfg
+++ b/data/overlayfiles/cloud-cfg-gdc/etc/cloud/cloud.cfg
@@ -1,0 +1,61 @@
+# Adapted default config for (open)SUSE systems
+
+users:
+ - default
+
+disable_root: true
+preserve_hostname: false
+syslog_fix_perms: root:root
+
+datasource_list: [ NoCloud ]
+
+# The modules that run in the 'init' stage
+cloud_init_modules:
+ - migrator
+ - bootcmd
+ - write-files
+ - growpart
+ - resizefs
+ - set_hostname
+ - update_hostname
+ - update_etc_hosts
+ - ca-certs
+ - rsyslog
+ - users-groups
+ - ssh
+
+# The modules that run in the 'config' stage
+cloud_config_modules:
+ - mounts
+ - locale
+ - set-passwords
+ - timezone
+ - puppet
+ - chef
+ - salt-minion
+ - mcollective
+ - disable-ec2-metadata
+ - runcmd
+ - byobu
+
+# The modules that run in the 'final' stage
+cloud_final_modules:
+ - package-update-upgrade-install
+ - rightscale_userdata
+ - scripts-per-once
+ - scripts-per-boot
+ - scripts-per-instance
+ - scripts-user
+ - ssh-authkey-fingerprints
+ - keys-to-console
+ - phone-home
+ - final-message
+ - power-state-change
+
+# System and/or distro specific settings
+system_info:
+   distro: sles
+   paths:
+      cloud_dir: /var/lib/cloud/
+      templates_dir: /etc/cloud/templates/
+   ssh_svcname: sshd

--- a/data/overlayfiles/sysconfig-network-plain1/etc/sysconfig/network/ifcfg-eth1
+++ b/data/overlayfiles/sysconfig-network-plain1/etc/sysconfig/network/ifcfg-eth1
@@ -1,0 +1,2 @@
+BOOTPROTO='dhcp+autoip'
+STARTMODE='auto'

--- a/images/cross-cloud/sles/chost/15-sp5/preferences.yaml
+++ b/images/cross-cloud/sles/chost/15-sp5/preferences.yaml
@@ -40,3 +40,8 @@ image:
       _include:
         - csp/sap-converged-cloud/settings/chost
         - products/chost
+    - _attributes:
+        profiles: [GDC]
+      _include:
+        - csp/gdc/settings/chost
+        - products/chost

--- a/images/cross-cloud/sles/chost/15-sp6/preferences.yaml
+++ b/images/cross-cloud/sles/chost/15-sp6/preferences.yaml
@@ -40,3 +40,8 @@ image:
       _include:
         - csp/sap-converged-cloud/settings/chost
         - products/chost
+    - _attributes:
+        profiles: [GDC]
+      _include:
+        - csp/gdc/settings/chost
+        - products/chost

--- a/images/cross-cloud/sles/chost/content.yaml
+++ b/images/cross-cloud/sles/chost/content.yaml
@@ -19,6 +19,9 @@ image:
       - _attributes:
           name: SAP-CCloud
           description: SAP Converged Cloud configuration
+      - _attributes:
+          name: GDC
+          description: Google Distributed Cloud configuration
   preferences:
     - _include:
         - base/common
@@ -51,6 +54,11 @@ image:
         profiles: [SAP-CCloud]
       _include:
         - csp/sap-converged-cloud/settings/chost
+        - products/chost
+    - _attributes:
+        profiles: [GDC]
+      _include:
+        - csp/gdc/settings/chost
         - products/chost
   packages:
     - _attributes:
@@ -104,6 +112,14 @@ image:
         profiles: [SAP-CCloud]
       _include:
         - csp/sap-converged-cloud/settings/chost
+    - _attributes:
+        type: image
+        profiles: [GDC]
+      _include:
+        - csp/gdc/settings/chost
+      archive:
+        - _attributes:
+            name: gdc.tar.gz
 config:
   - _include:
       - base/common
@@ -126,6 +142,9 @@ config:
   - profiles: [SAP-CCloud]
     _include:
       - csp/sap-converged-cloud/settings/chost
+  - profiles: [GDC]
+    _include:
+      - csp/gdc/settings/chost
 archive:
   - name: root.tar.gz
     _include:
@@ -144,3 +163,6 @@ archive:
   - name: gce.tar.gz
     _include:
       - csp/gce/settings/chost
+  - name: gdc.tar.gz
+    _include:
+      - csp/gdc/settings/chost


### PR DESCRIPTION
There is the intention to support HANA cloud on the Google Distributed Cloud (GDC) environment. Set up the image build to support GDC image import requirements.