### PR TITLE
kernel command line update

### DIFF
--- a/data/csp/aliyun/sle15/preferences.yaml
+++ b/data/csp/aliyun/sle15/preferences.yaml
@@ -10,6 +10,7 @@ preferences:
         console: ["tty0", "ttyS0,115200n8"]
         multipath: "off"
         NON_PERSISTENT_DEVICE_NAMES: 1
+        systemd.unified_cgroup_hierarchy: 1
     size:
       _attributes:
         unit: M

--- a/data/csp/azure-baremetal/sle15/preferences.yaml
+++ b/data/csp/azure-baremetal/sle15/preferences.yaml
@@ -16,6 +16,7 @@ preferences:
         processor.max_cstate: 1
         transparent_hugepage: never
         splash: verbose
+        systemd.unified_cgroup_hierarchy: 1
       image: oem
     bootloader: Null
     size: Null

--- a/data/csp/azure/sle15/preferences.yaml
+++ b/data/csp/azure/sle15/preferences.yaml
@@ -16,6 +16,7 @@ preferences:
         rootdelay: 300
         scsi_mod.use_blk_mq: 1
         USE_BY_UUID_DEVICE_NAMES: 1
+        systemd.unified_cgroup_hierarchy: 1
     size:
       _attributes:
         unit: M

--- a/data/csp/ec2/sle15/preferences.yaml
+++ b/data/csp/ec2/sle15/preferences.yaml
@@ -8,6 +8,7 @@ preferences:
         multipath: "off"
         nvme_core.admin_timeout: 4294967295
         nvme_core.io_timeout: 4294967295
+        systemd.unified_cgroup_hierarchy: 1
     machine:
       _attributes:
         xen_loader: hvmloader

--- a/data/csp/gce/sle15/preferences.yaml
+++ b/data/csp/gce/sle15/preferences.yaml
@@ -7,3 +7,4 @@ preferences:
         console: ttyS0,115200
         dis_ucode_ldr: []
         multipath: "off"
+        systemd.unified_cgroup_hierarchy: 1

--- a/data/csp/gdc/sle15/preferences.yaml
+++ b/data/csp/gdc/sle15/preferences.yaml
@@ -9,3 +9,4 @@ preferences:
         ci.datasource: NoCloud
         multipath: "off"
         NON_PERSISTENT_DEVICE_NAMES: 1
+        systemd.unified_cgroup_hierarchy: 1

--- a/data/csp/oci/sle15/preferences.yaml
+++ b/data/csp/oci/sle15/preferences.yaml
@@ -18,3 +18,4 @@ preferences:
         transparent_hugepage: never
         multipath: off
         root: /dev/sda3
+        systemd.unified_cgroup_hierarchy: 1


### PR DESCRIPTION
Better support for rootless containers using podman. We want to make as easy as possible for our users to run containers. For rootless containers it is recommended to us cgroups v2. Set the kernel command line option for systemd to use cgroups v2.