### PR TITLE
Setup fixes

### DIFF
--- a/data/csp/gdc/sle15/preferences.yaml
+++ b/data/csp/gdc/sle15/preferences.yaml
@@ -1,7 +1,7 @@
 preferences:
   type:
     _attributes:
-      firmware: Null
+      firmware: uefi
       format: qcow2
       vga: normal
       kernelcmdline:

--- a/data/csp/sap-converged-cloud/sle15/preferences.yaml
+++ b/data/csp/sap-converged-cloud/sle15/preferences.yaml
@@ -8,6 +8,7 @@ preferences:
         console: ["ttyS0,115200n8", "tty0"]
         NON_PERSISTENT_DEVICE_NAMES: 1
         multipath: "off"
+        systemd.unified_cgroup_hierarchy: 1
       vga: normal
     machine:
       _attributes:


### PR DESCRIPTION
- For GDC we need to setup the firmware to be uefi to support UEFI boot. This was missed in the initial commit for the GDC setup.
- Add cgroup v2 setting also for CCloud, we want this setting on all our images to support rootless containers.