### PR TITLE
Change Micro 5.5 instance initialization

### DIFF
--- a/data/csp/azure/settings/micro/sle15/sp5/config.yaml
+++ b/data/csp/azure/settings/micro/sle15/sp5/config.yaml
@@ -1,0 +1,9 @@
+config:
+  services:
+    azure-afterburn-checkin: Null
+    azure-micro-init:
+      - cloud-config
+      - cloud-final
+      - cloud-init
+      - cloud-init-local
+      - waagent

--- a/data/csp/azure/settings/micro/sle15/sp5/overlayfiles.yaml
+++ b/data/csp/azure/settings/micro/sle15/sp5/overlayfiles.yaml
@@ -1,0 +1,5 @@
+archive:
+  _namespace_azure_cloud_init_cfg:
+    _include_overlays:
+      - cloud-cfg-azure
+      - cloud-cfg-disable-network-config

--- a/data/csp/azure/settings/micro/sle15/sp5/packages.yaml
+++ b/data/csp/azure/settings/micro/sle15/sp5/packages.yaml
@@ -1,0 +1,8 @@
+packages:
+  _namespace_azure_micro:
+    package:
+      - cloud-init
+      - cloud-init-config-suse
+      - python-azure-agent
+      - python-azure-agent-config-micro
+      - python3-azuremetadata

--- a/data/csp/azure/settings/micro/sle15/sp5/preferences.yaml
+++ b/data/csp/azure/settings/micro/sle15/sp5/preferences.yaml
@@ -1,0 +1,5 @@
+preferences:
+  type:
+    _attributes:
+      kernelcmdline:
+        ignition.platform.id: Null

--- a/data/csp/ec2/settings/micro/sle15/sp5/config.yaml
+++ b/data/csp/ec2/settings/micro/sle15/sp5/config.yaml
@@ -1,0 +1,7 @@
+config:
+  services:
+    ec2-services-micro:
+      - cloud-config
+      - cloud-final
+      - cloud-init
+      - cloud-init-local

--- a/data/csp/ec2/settings/micro/sle15/sp5/overlayfiles.yaml
+++ b/data/csp/ec2/settings/micro/sle15/sp5/overlayfiles.yaml
@@ -1,0 +1,5 @@
+archive:
+  _namespace_ec2_cloud_init_cfg:
+    _include_overlays:
+      - cloud-cfg-ec2
+      - cloud-cfg-disable-network-config

--- a/data/csp/ec2/settings/micro/sle15/sp5/packages.yaml
+++ b/data/csp/ec2/settings/micro/sle15/sp5/packages.yaml
@@ -1,0 +1,6 @@
+packages:
+  _namespace_ec2_micro_init:
+    package:
+      - cloud-init
+      - cloud-init-config-suse
+      - python3-ec2metadata

--- a/data/csp/ec2/settings/micro/sle15/sp5/preferences.yaml
+++ b/data/csp/ec2/settings/micro/sle15/sp5/preferences.yaml
@@ -1,0 +1,5 @@
+preferences:
+  type:
+    _attributes:
+      kernelcmdline:
+        ignition.platform.id: Null

--- a/data/csp/gce/settings/micro/sle15/sp5/config.yaml
+++ b/data/csp/gce/settings/micro/sle15/sp5/config.yaml
@@ -1,0 +1,8 @@
+config:
+  services:
+    gce-services-micro:
+      - google-guest-agent
+      - google-osconfig-agent
+      - google-oslogin-cache.timer
+      - google-shutdown-scripts
+      - google-startup-scripts

--- a/data/csp/gce/settings/micro/sle15/sp5/packages.yaml
+++ b/data/csp/gce/settings/micro/sle15/sp5/packages.yaml
@@ -1,0 +1,7 @@
+packages:
+  _namespace_gce_init_micro:
+    package:
+      - google-guest-agent
+      - google-guest-configs
+      - google-guest-oslogin
+      - google-osconfig-agent

--- a/data/csp/gce/settings/micro/sle15/sp5/preferences.yaml
+++ b/data/csp/gce/settings/micro/sle15/sp5/preferences.yaml
@@ -1,0 +1,5 @@
+preferences:
+  type:
+    _attributes:
+      kernelcmdline:
+        ignition.platform.id: Null

--- a/data/products/sle-micro/5.5/config.yaml
+++ b/data/products/sle-micro/5.5/config.yaml
@@ -1,0 +1,5 @@
+config:
+  services:
+    sle-micro-services:
+      - boot.device-mapper
+      - docker

--- a/data/products/sle-micro/5.5/overlayfiles.yaml
+++ b/data/products/sle-micro/5.5/overlayfiles.yaml
@@ -1,0 +1,2 @@
+archive:
+  _namespace_sle_micro_ignition_config: Null

--- a/data/products/sle-micro/5.5/packages.yaml
+++ b/data/products/sle-micro/5.5/packages.yaml
@@ -1,0 +1,2 @@
+packages:
+  _namespace_sle_micro_init: Null

--- a/data/products/sle-micro/5.5/preferences.yaml
+++ b/data/products/sle-micro/5.5/preferences.yaml
@@ -1,0 +1,7 @@
+preferences:
+  type:
+    _attributes:
+      kernelcmdline:
+        ip: Null
+        rd.neednet: Null
+        "\\$ignition_firstboot": Null

--- a/data/products/sle-micro/overlayfiles.yaml
+++ b/data/products/sle-micro/overlayfiles.yaml
@@ -6,6 +6,8 @@ archive:
   _namespace_sle_micro_base:
     _include_overlays:
       - dracut-growfs
-      - ignition-user-config
       - sysctl-enable-ip-forward
       - sysctl-enable-rp-filter
+  _namespace_sle_micro_ignition_config:
+    _include_overlays:
+      - ignition-user-config

--- a/data/products/sle-micro/packages.yaml
+++ b/data/products/sle-micro/packages.yaml
@@ -4,7 +4,6 @@ packages:
       - _attributes:
           name: microos-salt_minion
     package:
-      - afterburn
       - btrfsmaintenance
       - btrfsprogs
       - ca-certificates
@@ -19,8 +18,6 @@ packages:
       - docker
       - glibc-locale-base
       - growpart-generator
-      - ignition
-      - ignition-dracut-grub2
       - issue-generator
       - health-checker
       - health-checker-plugins-MicroOS
@@ -50,3 +47,8 @@ packages:
     package:
       - cockpit-wicked
       - wicked
+  _namespace_sle_micro_init:
+    package:
+      - afterburn
+      - ignition
+      - ignition-dracut-grub2


### PR DESCRIPTION
Convert Micro 5.5 recipes from Ignition+Afterburn to cloud-init, Azure agent, and Google guest agent.