### PR TITLE
Enable cloud-init for GDC

### DIFF
--- a/data/csp/gdc/sle15/config.yaml
+++ b/data/csp/gdc/sle15/config.yaml
@@ -1,0 +1,7 @@
+config:
+  services:
+    gdc-services:
+      - cloud-config
+      - cloud-final
+      - cloud-init
+      - cloud-init-local


### PR DESCRIPTION
We want to enable the cloud-init services and not depend on the generator to enable cloud-init automatically. This brings the GDC setup in line with other flavors.