### PR TITLE
Allow DHCP assignment of link local addresses

### DIFF
--- a/data/csp/gce/sle15/overlayfiles.yaml
+++ b/data/csp/gce/sle15/overlayfiles.yaml
@@ -12,3 +12,7 @@ archive:
   _namespace_gce_virtio_net:
     _include_overlays:
       - module-virtio-net
+  _namespace_gce_allow_ll_dhcp:
+    _include_overlays:
+      # jira PED-10372 bsc#1229121 (remove when IPv6 IMDS implemented in GCE)
+      - wicked-allow-link-local-dhcp

--- a/data/overlayfiles/wicked-allow-link-local-dhcp/etc/wicked/local.xml
+++ b/data/overlayfiles/wicked-allow-link-local-dhcp/etc/wicked/local.xml
@@ -1,0 +1,9 @@
+<config>
+  <addrconf>
+    <dhcp4>
+      <!-- device name="eth0" -->
+        <ignore-rfc3927-1-6>true</ignore-rfc3927-1-6>
+      <!-- /device -->
+    </dhcp4>
+  </addrconf>
+</config>


### PR DESCRIPTION
Configure wicked to allow assignemnt of IPv4 link local addresses via DHCP (Jira PED-10372, bsc#1229121).