### PR TITLE
GDC image build

### DIFF
--- a/data/csp/gdc/sle15/overlayfiles.yaml
+++ b/data/csp/gdc/sle15/overlayfiles.yaml
@@ -2,6 +2,7 @@ archive:
   _namespace_gdc_base:
     _include_overlays:
       - chrony-gdc-ntp
+      - sysconfig-network-plain  
       - sysconfig-network-plain1
       - dracut-xfs
   _namespace_gdc_cloud_init_cfg:


### PR DESCRIPTION
We also need the eth0 configuration. THis was thought to be inherited but is not. Therefore explicitly add the eth0 configuration setup to the image build.