### PR TITLE
Fixes for SLE Micro 6 recipe

### DIFF
--- a/data/base/ondemand/alp/config.yaml
+++ b/data/base/ondemand/alp/config.yaml
@@ -1,0 +1,4 @@
+config:
+  services:
+    guestregister:
+      - guestregister

--- a/data/products/sle-micro/6.0/packages.yaml
+++ b/data/products/sle-micro/6.0/packages.yaml
@@ -5,6 +5,7 @@ packages:
       - NetworkManager-branding-SLE
       - SLE-Micro-release
       - systemd-default-settings-branding-SLE-Micro
+  _namespace_sle_micro_init: Null
   _namespace_sle_micro_network_mgmt: Null
   _namespace_sle_micro_cockpit:
     package:


### PR DESCRIPTION
Do not include Ignition and Afterburn (accidentally added due to changes in Micro 5.5 instance init setup).
Enable service `guestregister` in SLFO based PAYG recipes.