### PR TITLE
Add podman (bsc#1225988)

### DIFF
--- a/data/products/sle-micro/5.5/packages.yaml
+++ b/data/products/sle-micro/5.5/packages.yaml
@@ -1,2 +1,5 @@
 packages:
   _namespace_sle_micro_init: Null
+  _namespace_sle_micro_podman:
+    package:
+      - podman

--- a/data/products/sle-micro/6.0/packages.yaml
+++ b/data/products/sle-micro/6.0/packages.yaml
@@ -3,6 +3,7 @@ packages:
     namedCollection: Null
     package:
       - NetworkManager-branding-SLE
+      - podman
       - SLE-Micro-release
       - systemd-default-settings-branding-SLE-Micro
   _namespace_sle_micro_init: Null


### PR DESCRIPTION
This adds `podman` to SLE Micro 5.5 and also explicitly to Micro 6.0 (currently only included as a dependency of `cockpit-podman`).

Do we still keep `docker`?