### PR TITLE
Drop arch setting for the shim package

### DIFF
--- a/data/csp/alp/defaults.yaml
+++ b/data/csp/alp/defaults.yaml
@@ -18,7 +18,6 @@ packages:
     package:
       - _attributes:
           name: shim
-          arch: x86_64
 preferences:
   type:
     _attributes:

--- a/data/csp/azure/settings/chost/sle15/sp4/packages.yaml
+++ b/data/csp/azure/settings/chost/sle15/sp4/packages.yaml
@@ -1,0 +1,5 @@
+packages:
+  _namespace_azure_shim:
+    package:
+      - _attributes:
+          name: shim

--- a/data/csp/azure/settings/sapcal/sle15/sp4/packages.yaml
+++ b/data/csp/azure/settings/sapcal/sle15/sp4/packages.yaml
@@ -1,0 +1,5 @@
+packages:
+  _namespace_azure_shim:
+    package:
+      - _attributes:
+          name: shim

--- a/data/csp/azure/sle15/sp4/packages.yaml
+++ b/data/csp/azure/sle15/sp4/packages.yaml
@@ -5,3 +5,7 @@ packages:
       - lsscsi
       - python311-azure-sdk
       - python3-azuremetadata
+  _namespace_azure_shim:
+    package:
+      - _attributes:
+          name: shim

--- a/data/csp/sle15/sp4/defaults.yaml
+++ b/data/csp/sle15/sp4/defaults.yaml
@@ -1,0 +1,5 @@
+packages:
+  _namespace_default_shim:
+    package:
+      - _attributes:
+          name: shim


### PR DESCRIPTION
As of 15 Sp3 we have a signed shim package for aarch64. With 15 SP4 and forward we want to support secure boot with aarch64 in the Public Cloud. Therefore we drop the arch setting when including the package to pull it into builds for x86_64 and aarch64.