### PR TITLE
Add insserv-compat (bsc#1231279)

### DIFF
--- a/data/csp/azure/sle15/sp6/packages.yaml
+++ b/data/csp/azure/sle15/sp6/packages.yaml
@@ -1,0 +1,5 @@
+packages:
+  _namespace_azure_insserv_compat:
+    package:
+      # required by AzureMonitorLinuxAgent extension (bsc#1231279)
+      - insserv-compat


### PR DESCRIPTION
Required by AzureMonitorAgent WA Agent extension.