### PR TITLE
Increase default and max socket buffer sizes (bsc#1223566)

### DIFF
--- a/data/csp/azure/settings/sap/sle15/overlayfiles.yaml
+++ b/data/csp/azure/settings/sap/sle15/overlayfiles.yaml
@@ -1,0 +1,4 @@
+archive:
+  _namespace_azure_sap_sockbuf:
+    _include_overlays:
+      - sysctl-large-socket-buffer

--- a/data/csp/azure/sle15/overlayfiles.yaml
+++ b/data/csp/azure/sle15/overlayfiles.yaml
@@ -18,6 +18,3 @@ archive:
   _namespace_azure_sysconfig_network:
     _include_overlays:
       - sysconfig-network-cloud-netconfig
-  _namespace_azure_sysctl_sockbuf:
-    _include_overlays:
-      - sysctl-large-socket-buffer

--- a/data/csp/azure/sle15/overlayfiles.yaml
+++ b/data/csp/azure/sle15/overlayfiles.yaml
@@ -18,3 +18,6 @@ archive:
   _namespace_azure_sysconfig_network:
     _include_overlays:
       - sysconfig-network-cloud-netconfig
+  _namespace_azure_sysctl_sockbuf:
+    _include_overlays:
+      - sysctl-large-socket-buffer

--- a/data/overlayfiles/sysctl-large-socket-buffer/etc/sysctl.d/rmem.conf
+++ b/data/overlayfiles/sysctl-large-socket-buffer/etc/sysctl.d/rmem.conf
@@ -1,0 +1,2 @@
+net.core.rmem_default = 1048576
+net.core.rmem_max = 2500000


### PR DESCRIPTION
This increases the default socket buffer size to 1048576 bytes as requested in bsc#1223566 and the max to 2500000 bytes (as newer kernels use as default) for all Azure images. Should this perhaps be set for all platforms to be uniform? Also, should this be limited to SLES for SAP only (the platform the bug was reported for)?