### PR TITLE
Re-add dracut xfs config module

### DIFF
--- a/data/overlayfiles/dracut-xfs/etc/dracut.conf.d/07-xfs.conf
+++ b/data/overlayfiles/dracut-xfs/etc/dracut.conf.d/07-xfs.conf
@@ -1,0 +1,1 @@
+add_drivers+=" xfs "


### PR DESCRIPTION
This adds dracut xfs config overlay module back as it is required by GDC CHOST profile, which does not use a dracut config package.