### PR TITLE
Create empty /etc/security/opasswd

### DIFF
--- a/data/scripts/pcs-hardening-workarounds.sh
+++ b/data/scripts/pcs-hardening-workarounds.sh
@@ -49,3 +49,8 @@ while IFS= read -r -d '' link; do
     target=$(readlink -f "$link")
     cp -p --remove-destination "$target" "$link"
 done
+
+# create empty /etc/security/opasswd file, otherwise mitigation for
+# xccdf_org.ssgproject.content_rule_file_etc_security_opasswd will fail
+touch /etc/security/opasswd
+chmod 600 /etc/security/opasswd


### PR DESCRIPTION
Rule `xccdf_org.ssgproject.content_rule_file_etc_security_opasswd` fails if file is absent, which is the case in a newly created image.