### PR TITLE
Enable IPv6 forwarding in CHOST 15 SP5+

### DIFF
--- a/data/overlayfiles/sysctl-enable-ipv6-forward/etc/sysctl.d/net_ipv6_conf_all_accept_ra.conf
+++ b/data/overlayfiles/sysctl-enable-ipv6-forward/etc/sysctl.d/net_ipv6_conf_all_accept_ra.conf
@@ -1,0 +1,2 @@
+# Accept router announcents even with IP forward enabled
+net.ipv6.conf.all.accept_ra = 2

--- a/data/overlayfiles/sysctl-enable-ipv6-forward/etc/sysctl.d/net_ipv6_conf_all_forwarding.conf
+++ b/data/overlayfiles/sysctl-enable-ipv6-forward/etc/sysctl.d/net_ipv6_conf_all_forwarding.conf
@@ -1,0 +1,1 @@
+net.ipv6.conf.all.forwarding = 1

--- a/data/products/chost/sle15/sp5/overlayfiles.yaml
+++ b/data/products/chost/sle15/sp5/overlayfiles.yaml
@@ -1,0 +1,4 @@
+archive:
+  _namespace_chost_ipv6_forward:
+    _include_overlays:
+      - sysctl-enable-ipv6-forward


### PR DESCRIPTION
Enable IPv6 forwarding and accept IPv6 router annoucements.