### PR TITLE
Do not enable IPv6 forwarding

### DIFF
--- a/data/products/chost/sle15/sp5/overlayfiles.yaml
+++ b/data/products/chost/sle15/sp5/overlayfiles.yaml
@@ -1,4 +1,0 @@
-archive:
-  _namespace_chost_ipv6_forward:
-    _include_overlays:
-      - sysctl-enable-ipv6-forward


### PR DESCRIPTION
This changes the CHOST recipe to not include the IPv6 related sysctl files in the overlay but keeps them in keg-recipes for now in case they are needed after all.