### PR TITLE
Disable KBD numlock (bsc#1230336)

### DIFF
--- a/data/base/common/sle15/sp4/config.yaml
+++ b/data/base/common/sle15/sp4/config.yaml
@@ -1,0 +1,7 @@
+config:
+  sysconfig:
+    common-kbd-numlock:
+      # work-around for bsc#1230336
+      - file: /etc/sysconfig/keyboard
+        name: KBD_NUMLOCK
+        value: "no"

--- a/data/base/common/sle15/sp7/config.yaml
+++ b/data/base/common/sle15/sp7/config.yaml
@@ -1,0 +1,3 @@
+config:
+  sysconfig:
+    common-kbd-numlock: Null


### PR DESCRIPTION
Disable KBB numlock to work around kernel crash with TDX.