### PR TITLE
Do not use boot partition (bsc#1237281)

### DIFF
--- a/data/csp/azure/settings/suma-proxy/sle15/sp5/preferences.yaml
+++ b/data/csp/azure/settings/suma-proxy/sle15/sp5/preferences.yaml
@@ -1,0 +1,5 @@
+preferences:
+  type:
+    _attributes:
+      bootpartition: Null
+      bootpartsize: Null

--- a/data/csp/azure/settings/suma-server/sle15/sp5/preferences.yaml
+++ b/data/csp/azure/settings/suma-server/sle15/sp5/preferences.yaml
@@ -1,0 +1,5 @@
+preferences:
+  type:
+    _attributes:
+      bootpartition: Null
+      bootpartsize: Null


### PR DESCRIPTION
Do not use boot partition for SUSE Manager 5 in Azure.