### PR TITLE
Fix SUSE Manager Proxy image definition preferences

### DIFF
--- a/images/cross-cloud/suse-manager/proxy/5.0/content.yaml
+++ b/images/cross-cloud/suse-manager/proxy/5.0/content.yaml
@@ -17,7 +17,7 @@ image:
         profiles: [Azure]
         arch: x86_64
       _include:
-        - csp/azure/settings/suma
+        - csp/azure/settings/suma-proxy
         - products/suse-manager/x86_64
         - products/suse-manager/proxy
     - _attributes:


### PR DESCRIPTION
Fix typo in preferences section in SUSE Manager Proxy 5.0 image definition.