### PR TITLE
Add package grub2-snapper-plugin

### DIFF
--- a/data/products/sle-micro/packages.yaml
+++ b/data/products/sle-micro/packages.yaml
@@ -18,6 +18,7 @@ packages:
       - docker
       - glibc-locale-base
       - growpart-generator
+      - grub2-snapper-plugin
       - issue-generator
       - health-checker
       - health-checker-plugins-MicroOS

--- a/data/products/suse-manager/sle15/sp5/packages.yaml
+++ b/data/products/suse-manager/sle15/sp5/packages.yaml
@@ -17,6 +17,7 @@ packages:
       - distribution-release
       - docker
       - glibc-locale-base
+      - grub2-snapper-plugin
       - issue-generator
       - health-checker
       - health-checker-plugins-MicroOS


### PR DESCRIPTION
Add `grub2-snapper-plugin` to SLE Micro 5.x and SUSE Manager 5.0 recipes.