### PR TITLE
Drop instance-billing-flavor check from CHOST and Azure LI/VLI

### DIFF
--- a/data/base/common/sle15/packages.yaml
+++ b/data/base/common/sle15/packages.yaml
@@ -12,7 +12,6 @@ packages:
       - kdump
       - openssh
       - parted
-      - python-instance-billing-flavor-check
       - sudo
       - supportutils
       - suse-build-key

--- a/data/products/chost/sle15/packages.yaml
+++ b/data/products/chost/sle15/packages.yaml
@@ -44,3 +44,4 @@ packages:
       - sle-module-public-cloud-release
       - sles-release
   _namespace_yast2_schema: Null
+  _namespace_billing_flavor_check: Null

--- a/data/products/sap/azure-baremetal/sle15/packages.yaml
+++ b/data/products/sap/azure-baremetal/sle15/packages.yaml
@@ -1,0 +1,2 @@
+packages:
+  _namespace_billing_flavor_check: Null

--- a/data/products/sle15/defaults.yaml
+++ b/data/products/sle15/defaults.yaml
@@ -6,3 +6,6 @@ packages:
   _namespace_yast2_schema:
     package:
       - yast2-schema
+  _namespace_billing_flavor_check:
+    package:
+      - python-instance-billing-flavor-check

--- a/images/single-cloud/azure-li/content.yaml
+++ b/images/single-cloud/azure-li/content.yaml
@@ -30,7 +30,7 @@ image:
         - base/common
         - base/sle
         - csp/azure-baremetal/li
-        - products/sap
+        - products/sap/azure-baremetal
 config:
   - _include:
       - base/common

--- a/images/single-cloud/azure-vli/content.yaml
+++ b/images/single-cloud/azure-vli/content.yaml
@@ -30,7 +30,7 @@ image:
         - base/common
         - base/sle
         - csp/azure-baremetal/vli
-        - products/sap
+        - products/sap/azure-baremetal
 config:
   - _include:
       - base/common


### PR DESCRIPTION
Drop package to avoid cloud-regionsrv-client being pulled into builds.