### PR TITLE
Disable password based login for ssh

### DIFF
--- a/data/scripts/ssh-disable-challenge-response-auth.sh
+++ b/data/scripts/ssh-disable-challenge-response-auth.sh
@@ -1,3 +1,7 @@
 test -f /etc/ssh/sshd_config || cp /usr/etc/ssh/sshd_config /etc/ssh/
 sed -i -e "s/#ChallengeResponseAuthentication yes/ChallengeResponseAuthentication no/" \
     /etc/ssh/sshd_config
+# For the SSHv2 protocol ChallengeResponseAuthentication was replaced by
+# KbdInteractiveAuthentication
+sed -i -e "s/#KbdInteractiveAuthentication yes/KbdInteractiveAuthentication no/" \
+    /etc/ssh/sshd_config


### PR DESCRIPTION
Depending on the protocol version for SSH we need to set either ChallengeResponseAuthentication or KbdInteractiveAuthentication to "no". Prior to this change we only set ChallengeResponseAuthentication allowing password based login when the SSHv2 protocol is used. We now modify newer config files appropriately.