### PR TITLE
No root login with password over ssh

### DIFF
--- a/data/csp/ec2/sle15/sp6/packages.yaml
+++ b/data/csp/ec2/sle15/sp6/packages.yaml
@@ -1,0 +1,4 @@
+packages:
+  _namespace_no_ssh_pwd_root_login:
+    package:
+      - openssh-server-config-disallow-rootlogin

--- a/data/csp/gce/sle15/sp6/packages.yaml
+++ b/data/csp/gce/sle15/sp6/packages.yaml
@@ -1,0 +1,4 @@
+packages:
+  _namespace_no_ssh_pwd_root_login:
+    package:
+      - openssh-server-config-disallow-rootlogin


### PR DESCRIPTION
Do not allow root to login via ssh using a password. While we already have measures in place to make it difficult to setup password based login via ssh, this adds another layer addressing the root user. Cloud instances should only used key based login.