### PR TITLE
Use cgroup v1 for CHOST flavor builds

### DIFF
--- a/data/csp/gdc/sle15/preferences.yaml
+++ b/data/csp/gdc/sle15/preferences.yaml
@@ -9,4 +9,3 @@ preferences:
         ci.datasource: NoCloud
         multipath: "off"
         NON_PERSISTENT_DEVICE_NAMES: 1
-        systemd.unified_cgroup_hierarchy: 1

--- a/data/csp/sap-converged-cloud/sle15/preferences.yaml
+++ b/data/csp/sap-converged-cloud/sle15/preferences.yaml
@@ -8,7 +8,6 @@ preferences:
         console: ["ttyS0,115200n8", "tty0"]
         NON_PERSISTENT_DEVICE_NAMES: 1
         multipath: "off"
-        systemd.unified_cgroup_hierarchy: 1
       vga: normal
     machine:
       _attributes:

--- a/data/products/chost/sle15/sp4/preferences.yaml
+++ b/data/products/chost/sle15/sp4/preferences.yaml
@@ -3,3 +3,4 @@ preferences:
     _attributes:
       kernelcmdline:
         cgroup.memory: Null
+        systemd.unified_cgroup_hierarchy: Null


### PR DESCRIPTION
SAP is reporting issues with the v2 cgroup setting and requesting we go back to v1. Given that we have no othet known consumers of the CHOST images we honor this request. That said the change to v1 may cause issues with k8s (https://kubernetes.io/docs/concepts/architecture/cgroups/).