### PR TITLE
Add work-around for broken hardening rule (bsc#1241615)

### DIFF
--- a/data/scripts/pcs-hardening-workarounds.sh
+++ b/data/scripts/pcs-hardening-workarounds.sh
@@ -42,6 +42,14 @@ for rule in $rules_to_disable ; do
     sed -i -e "/$rule/ s/selected=\"true\"/selected=\"false\"/" $ssg_file
 done
 
+# temp fix for missing filepath in limit password reuse rule (bsc#1241615)
+sed -i -e \
+   '/textfilecontent54_object id="oval:ssg-object_accounts_password_pam_pwhistory_remember/{ :n N;
+        /<\/ind:textfilecontent54_object>/ { /<ind:filepath\/>/ {
+            s;<ind:filepath/>;<ind:filepath>/etc/pam.d/common-password</ind:filepath>; } ;b
+        }; bn
+    }' $ssg_file
+
 # run pam_disable_automatic_configuration remediation directly, to
 # mitigate disabling of the rule
 find /etc/pam.d/ -type l -iname "common-*" -print0 | \


### PR DESCRIPTION
Add temporary work-around for broken evaluation of limit password reuse hardening rule.

The rule in question refers to two `textfilecontent54` objects in the SSG xml file that both have an empty `filepath` tag. This PR adds a sed command to the `images.sh` script that sets the tags to the expected `/etc/pam.d/common-password` value in case they are empty.