### PR TITLE
Use kiwi schema version 7.5

### DIFF
--- a/data/products/sle-micro/6.0/packages.yaml
+++ b/data/products/sle-micro/6.0/packages.yaml
@@ -19,3 +19,6 @@ packages:
       - cockpit-system
       - cockpit-tukit
       - cockpit-ws
+  _namespace_sle_micro_kiwi_resize:
+    package:
+      - dracut-kiwi-oem-repart

--- a/data/products/sle-micro/6.0/preferences.yaml
+++ b/data/products/sle-micro/6.0/preferences.yaml
@@ -1,5 +1,8 @@
 preferences:
   type:
     _attributes:
+      image: oem
       kernelcmdline:
         systemd.unified_cgroup_hierarchy: 1
+    oemconfig:
+      oem-resize: "false"

--- a/data/products/sle-micro/6.0/preferences.yaml
+++ b/data/products/sle-micro/6.0/preferences.yaml
@@ -4,5 +4,3 @@ preferences:
       image: oem
       kernelcmdline:
         systemd.unified_cgroup_hierarchy: 1
-    oemconfig:
-      oem-resize: "false"

--- a/data/products/sle-micro/6.1/packages.yaml
+++ b/data/products/sle-micro/6.1/packages.yaml
@@ -1,4 +1,0 @@
-packages:
-  _namespace_sle_micro_kiwi_resize:
-    package:
-      - dracut-kiwi-oem-repart

--- a/images/cross-cloud/sle-micro/byos/6.0/image.yaml
+++ b/images/cross-cloud/sle-micro/byos/6.0/image.yaml
@@ -5,7 +5,7 @@ image-config-comments:
   obs-ignore-rpm: Null
 image:
   _attributes:
-    schemaversion: "7.2"
+    schemaversion: "7.5"
     name: SLE-Micro-6-0-BYOS
     displayname: SLE-Micro-6-0-BYOS
   description:

--- a/images/cross-cloud/sle-micro/ondemand/6.0/image.yaml
+++ b/images/cross-cloud/sle-micro/ondemand/6.0/image.yaml
@@ -5,7 +5,7 @@ image-config-comments:
   obs-ignore-rpm: Null
 image:
   _attributes:
-    schemaversion: "7.2"
+    schemaversion: "7.5"
     name: SLE-Micro-6-0
     displayname: SLE-Micro-6-0
   description:


### PR DESCRIPTION
Use kiwi schema version 7.5 for SL Micro 6.0.

This is needed because kiwi in SL Micro 6.0 does not support schema versions <= 7.4 anymore. The PR sets `oem-resize` to false so the kiwi dracut resizer does not get used. This would also disable it for 6.1, which I believe is still supposed to use cloud-init, but at the moment might be using the dracut resizer. We should probably also drop `dracut-kiwi-oem-repart` from 6.1 if we want to go through with this, or change this PR to enable `oem-resize` for 6.1 if not.