### PR TITLE
Add guestregister mlm51

### DIFF
--- a/data/products/suse-manager/micro/6.1/config.yaml
+++ b/data/products/suse-manager/micro/6.1/config.yaml
@@ -12,7 +12,6 @@ config:
     suma-services:
       - name: transactional-update.timer
         enable: False
-
     suma-services-guestregister:
       - guestregister
 

--- a/data/products/suse-manager/micro/6.1/config.yaml
+++ b/data/products/suse-manager/micro/6.1/config.yaml
@@ -12,3 +12,7 @@ config:
     suma-services:
       - name: transactional-update.timer
         enable: False
+
+    suma-services-guestregister:
+      - guestregister
+


### PR DESCRIPTION
MLM 5.1 PAYG should run the guestregister service at boot, like any
other PAYG image

This change fixes that

How to test:
create an image with this change, it should run the command at boot