### PR TITLE
Set the serial line

### DIFF
--- a/data/csp/gce/alp/preferences.yaml
+++ b/data/csp/gce/alp/preferences.yaml
@@ -6,6 +6,8 @@ preferences:
         console: ttyS0,115200
         dis_ucode_ldr: []
         multipath: "off"
+        systemd.unified_cgroup_hierarchy: 1
     bootloader:
       _attributes:
         console: serial
+        serial_line: serial --unit=0

--- a/data/csp/gce/sle15/preferences.yaml
+++ b/data/csp/gce/sle15/preferences.yaml
@@ -1,10 +1,13 @@
 preferences:
   type:
     _attributes:
-      bootloader_console: serial
       format: gce
       kernelcmdline:
         console: ttyS0,115200
         dis_ucode_ldr: []
         multipath: "off"
         systemd.unified_cgroup_hierarchy: 1
+    bootloader:
+      _attributes:
+        console: serial
+        serial_line: serial --unit=0


### PR DESCRIPTION
Explicitly set the serial line for grub to avoid auto probing which may result in a hang.