### PR TITLE
Include cloud-netconfig in CHOST image descriptions

### DIFF
--- a/data/csp/azure/settings/chost/sle15/packages.yaml
+++ b/data/csp/azure/settings/chost/sle15/packages.yaml
@@ -2,7 +2,6 @@ packages:
   _namespace_azure_rootgrow:
     package:
       - growpart-rootgrow
-  _namespace_azure_cloud_netconfig: Null
   _namespace_azure_cryptsetup: Null
   _namespace_azure_tools: Null
   _namespace_azure_regionsrv_client_addon: Null

--- a/data/csp/ec2/settings/chost/sle15/packages.yaml
+++ b/data/csp/ec2/settings/chost/sle15/packages.yaml
@@ -1,5 +1,4 @@
 packages:
-  _namespace_ec2_cloud_netconfig: Null
   _namespace_ec2_tools: Null
   _namespace_ec2_image_utils: Null
   _namespace_ec2_registration: Null

--- a/data/csp/gce/settings/chost/sle15/packages.yaml
+++ b/data/csp/gce/settings/chost/sle15/packages.yaml
@@ -1,5 +1,4 @@
 packages:
-  _namespace_gce_cloud_netconfig: Null
   _namespace_gce_patch: Null
   _namespace_gce_registration: Null
   _namespace_gce_tools: Null


### PR DESCRIPTION
Include cloud-netconfig in CHOST image descriptions which will disable the standard persistent network interface name generator as it can cause issue with cloned instances (bsc#1231521).

Please note this does not actually enable cloud-netconfig, i.e. no secondary IP addresses will be added and no routing policies will be created. It would still create ifcfg files for additional network interfaces. I'm not sure whether that's exactly what we want.