### PR TITLE
Force cgroups v1

### DIFF
--- a/data/products/chost/sle15/sp6/preferences.yaml
+++ b/data/products/chost/sle15/sp6/preferences.yaml
@@ -1,0 +1,6 @@
+preferences:
+  type:
+    _attributes:
+      kernelcmdline:
+        cgroup.memory: Null
+        systemd.unified_cgroup_hierarchy: 0


### PR DESCRIPTION
In SLE 15 SP6 the default behavior of the distribution changed and the cgroups v2 protocol is enabled by default. This triggers problem with the SAP HANA Cloud deployment. Force the cgroups protocol to v1 for the SP6 based CHOST images.