### PR TITLE
Do not include Azure Agent AutoUpdate work-around

### DIFF
--- a/data/csp/azure/settings/micro/sle15/sp4/config.yaml
+++ b/data/csp/azure/settings/micro/sle15/sp4/config.yaml
@@ -1,0 +1,3 @@
+config:
+  scripts:
+    azure-waagent-disable-auto-update: Null

--- a/data/csp/azure/settings/micro/sle15/sp5/config.yaml
+++ b/data/csp/azure/settings/micro/sle15/sp5/config.yaml
@@ -1,4 +1,8 @@
 config:
+  scripts:
+    azure-waagent-disable-auto-update:
+      # work-around for bsc#1244933 (remove once MU is done)
+      - waagent-disable-auto-update
   services:
     azure-afterburn-checkin: Null
     azure-micro-init:


### PR DESCRIPTION
Do not include Azure Agent AutoUpdate work-around in SLE Micro versions that do not use Azure Agent.