### PR TITLE
Limit maximum concurrent zypp connections

### DIFF
--- a/data/base/ondemand/alp/config.yaml
+++ b/data/base/ondemand/alp/config.yaml
@@ -1,4 +1,7 @@
 config:
+  scripts:
+    ondemand-config:
+      - zypp-limit-concurrent-downloads
   services:
     guestregister:
       - guestregister

--- a/data/base/ondemand/sle15/config.yaml
+++ b/data/base/ondemand/sle15/config.yaml
@@ -1,4 +1,7 @@
 config:
+  scripts:
+    ondemand-config:
+      - zypp-limit-concurrent-downloads
   services:
     guestregister:
       - guestregister

--- a/data/scripts/zypp-limit-concurrent-downloads.sh
+++ b/data/scripts/zypp-limit-concurrent-downloads.sh
@@ -1,0 +1,2 @@
+# limit number of concurrent connections to 1
+sed -i -e 's/^[# ]*download.max_concurrent_connections.*/download.max_concurrent_connections = 1/' /etc/zypp/zypp.conf


### PR DESCRIPTION
Limit maximum concurrent zypp connections to one for PAYG recipes.