### PR TITLE
Add supportutils-plugin-suse-public-cloud

### DIFF
--- a/data/products/sle-micro/6.0/packages.yaml
+++ b/data/products/sle-micro/6.0/packages.yaml
@@ -8,6 +8,7 @@ packages:
       - NetworkManager-branding-SLE
       - podman
       - SLE-Micro-release
+      - supportutils-plugin-suse-public-cloud
       - systemd-default-settings-branding-SLE-Micro
   _namespace_sle_micro_init: Null
   _namespace_sle_micro_network_mgmt: Null


### PR DESCRIPTION
Add supportutils-plugin-suse-public-cloud to SL Micro 6.x recipes (bsc#1246115).