### PR TITLE
Fix typo and rename file

### DIFF
--- a/data/overlayfiles/motd-mod-mlm-proxy-byos/usr/lib/motd.d/40_mlm_proxy_doc_links
+++ b/data/overlayfiles/motd-mod-mlm-proxy-byos/usr/lib/motd.d/40_mlm_proxy_doc_links
@@ -1,4 +1,4 @@
 
-Documentation: https://documentation.suse.com/multi-linux-manager/(EXTENSION_VERSION}
+Documentation: https://documentation.suse.com/multi-linux-manager/{EXTENSION_VERSION}
 BYOS Guide: https://documentation.suse.com/multi-linux-manager/{EXTENSION_VERSION}/en/docs/specialized-guides/public-cloud-guide/byos/byos-overview.html
 Community: https://forums.suse.com/c/suse-manager

--- a/data/overlayfiles/motd-mod-mlm-server-byos/usr/lib/motd.d/40_mlm_server_doc_links
+++ b/data/overlayfiles/motd-mod-mlm-server-byos/usr/lib/motd.d/40_mlm_server_doc_links
@@ -1,4 +1,4 @@
 
-Documentation: https://documentation.suse.com/multi-linux-manager/(EXTENSION_VERSION}
+Documentation: https://documentation.suse.com/multi-linux-manager/{EXTENSION_VERSION}
 BYOS Guide: https://documentation.suse.com/multi-linux-manage/{EXTENSION_VERSION}/en/docs/specialized-guides/public-cloud-guide/byos/byos-overview.html
 Community: https://forums.suse.com/c/suse-manager

--- a/data/overlayfiles/motd-mod-mlm-server-payg/usr/lib/motd.d/40_mlm_server_doc_links
+++ b/data/overlayfiles/motd-mod-mlm-server-payg/usr/lib/motd.d/40_mlm_server_doc_links
@@ -1,4 +1,4 @@
 
-Documentation: https://documentation.suse.com/multi-linux-manager/(EXTENSION_VERSION}
+Documentation: https://documentation.suse.com/multi-linux-manager/{EXTENSION_VERSION}
 PAYG Guide: https://documentation.suse.com/multi-linux-manager/{EXTENSION_VERSION}/en/docs/specialized-guides/public-cloud-guide/payg/payg-overview.html
 Community: https://forums.suse.com/c/suse-manager


### PR DESCRIPTION
- In the documentation link in motd a `(` needed to be replaced by `{`
- Renamed 40_mlm_proxy_doc_linkx to 40_mlm_proxy_doc_links