### PR TITLE
Drop supportutils-plugin-salt

### DIFF
--- a/data/products/suse-manager/server/sle15/packages.yaml
+++ b/data/products/suse-manager/server/sle15/packages.yaml
@@ -6,7 +6,6 @@ packages:
       - patterns-suma_server
       - salt-minion
       - spacecmd
-      - supportutils-plugin-salt
       - supportutils-plugin-susemanager
       - susemanager-cloud-setup-server
       - release-notes-sles


### PR DESCRIPTION
Drop supportutils-plugin-salt from SUSE Manager 4.3 recipe (bsc#1242071).