### PR TITLE
Drop unsupported packages

### DIFF
--- a/data/csp/ec2/alp/packages.yaml
+++ b/data/csp/ec2/alp/packages.yaml
@@ -7,6 +7,8 @@ packages:
       - _attributes:
           name: xen-libs
           arch: x86_64
+  _namespace_ec2_xen_tools:
+    package:
       - _attributes:
           name: xen-tools-domU
           arch: x86_64

--- a/data/csp/ec2/settings/micro/alp/packages.yaml
+++ b/data/csp/ec2/settings/micro/alp/packages.yaml
@@ -1,0 +1,2 @@
+packages:
+  _namespace_ec2_xen_tools: Null

--- a/data/csp/ec2/settings/micro/sle15/packages.yaml
+++ b/data/csp/ec2/settings/micro/sle15/packages.yaml
@@ -3,6 +3,7 @@ packages:
   _namespace_ec2_tools: Null
   _namespace_ec2_image_utils: Null
   _namespace_ec2_registration: Null
+  _namespace_ec2_xen_tools: Null
   _namespace_ec2_micro:
     package:
       - python3-ec2metadata

--- a/data/csp/ec2/settings/suma-proxy/sle15/packages.yaml
+++ b/data/csp/ec2/settings/suma-proxy/sle15/packages.yaml
@@ -1,6 +1,5 @@
 packages:
   _namespace_ec2_tools:
     package:
-      - amazon-ssm-agent
       - python3-ec2metadata
   _namespace_ec2_image_utils: Null

--- a/data/csp/ec2/settings/suma-server/sle15/packages.yaml
+++ b/data/csp/ec2/settings/suma-server/sle15/packages.yaml
@@ -1,6 +1,5 @@
 packages:
   _namespace_ec2_tools:
     package:
-      - amazon-ssm-agent
       - python3-ec2metadata
   _namespace_ec2_image_utils: Null

--- a/data/csp/ec2/sle15/packages.yaml
+++ b/data/csp/ec2/sle15/packages.yaml
@@ -7,6 +7,8 @@ packages:
       - _attributes:
           name: xen-libs
           arch: x86_64
+  _namespace_ec2_xen_tools:
+    package:
       - _attributes:
           name: xen-tools-domU
           arch: x86_64

--- a/data/products/suse-manager/proxy/micro/6.1/packages.yaml
+++ b/data/products/suse-manager/proxy/micro/6.1/packages.yaml
@@ -4,7 +4,6 @@ packages:
       - Multi-Linux-Manager-Proxy-release
   _namespace_mlm_proxy_base:
     package:
-      - bind-utils
       - jq
       - mgrpxy
       - mgrpxy-bash-completion

--- a/data/products/suse-manager/server/micro/6.1/packages.yaml
+++ b/data/products/suse-manager/server/micro/6.1/packages.yaml
@@ -5,7 +5,6 @@ packages:
   _namespace_manager_server_base:
     package:
       - aardvark-dns
-      - bind-utils
       - jq
       - netavark
       - mgradm


### PR DESCRIPTION
Drop packages from SL Micro and MLM recipes that are not supported in SL Micro (bsc#1247129), namely `xen-tools-domU`, `amazon-ssm-agent`, and `bind-utils`.