### PR TITLE
Remove rootgrow

### DIFF
--- a/data/csp/gce/alp/config.yaml
+++ b/data/csp/gce/alp/config.yaml
@@ -27,7 +27,6 @@ config:
       - google-oslogin-cache.timer
       - google-shutdown-scripts
       - google-startup-scripts
-      - rootgrow
     gce-cloud-netconfig:
       - cloud-netconfig.timer
     flex-license-timer:

--- a/data/csp/gce/alp/packages.yaml
+++ b/data/csp/gce/alp/packages.yaml
@@ -8,8 +8,6 @@ packages:
       - google-guest-configs
       - google-guest-oslogin
       - google-osconfig-agent
-      - growpart
-      - growpart-rootgrow
       - kernel-default
   _namespace_gce_tools:
     package:


### PR DESCRIPTION
Remove rootgrow from SL Micro 6.x GCE recipes as dracut-kiwi-oem-repart is used.