### PR TITLE
Drop xen-tools-domU from MLM 5.1

### DIFF
--- a/data/csp/ec2/settings/suma-proxy/micro/packages.yaml
+++ b/data/csp/ec2/settings/suma-proxy/micro/packages.yaml
@@ -1,0 +1,2 @@
+packages:
+  _namespace_ec2_xen_tools: Null

--- a/data/csp/ec2/settings/suma-server/micro/packages.yaml
+++ b/data/csp/ec2/settings/suma-server/micro/packages.yaml
@@ -1,0 +1,2 @@
+packages:
+  _namespace_ec2_xen_tools: Null


### PR DESCRIPTION
Drop xen-tools-domU also from MLM 5.1.