### PR TITLE
Add fuse to Azure LI/VLI SP<=4 recipe

### DIFF
--- a/data/csp/azure-baremetal/sle15/packages.yaml
+++ b/data/csp/azure-baremetal/sle15/packages.yaml
@@ -53,3 +53,7 @@ packages:
   _namespace_azure_baremetal_firewall:
     package:
       - SuSEfirewall2
+  _namespace_azure_baremetal_fuse:
+    package:
+      # dependency of xdg-desktop-portal <=SP4 that cannot be auto-resolved
+      - fuse

--- a/data/csp/azure-baremetal/sle15/sp5/packages.yaml
+++ b/data/csp/azure-baremetal/sle15/sp5/packages.yaml
@@ -1,0 +1,2 @@
+packages:
+  _namespace_azure_baremetal_fuse: Null


### PR DESCRIPTION
Add fuse to Azure LI/VLI SP<=4 recipe as xdg-desktop-portal requires /usr/bin/fusermount which cannot be automatically resolved.