### PR TITLE
Use wicked instead of NetworkManager

### DIFF
--- a/data/products/sle-micro/5.5/config.yaml
+++ b/data/products/sle-micro/5.5/config.yaml
@@ -3,3 +3,4 @@ config:
     sle-micro-services:
       - boot.device-mapper
       - docker
+      - wicked

--- a/data/products/sle-micro/5.5/packages.yaml
+++ b/data/products/sle-micro/5.5/packages.yaml
@@ -1,5 +1,9 @@
 packages:
   _namespace_sle_micro_init: Null
+  _namespace_sle_micro_network_mgmt:
+    package:
+      - cockpit-wicked
+      - wicked
   _namespace_sle_micro_podman:
     package:
       - acl

--- a/data/products/suse-manager/sle15/sp5/config.yaml
+++ b/data/products/suse-manager/sle15/sp5/config.yaml
@@ -12,3 +12,4 @@ config:
     suma-services:
       - name: transactional-update.timer
         enable: False
+      - wicked

--- a/data/products/suse-manager/sle15/sp5/packages.yaml
+++ b/data/products/suse-manager/sle15/sp5/packages.yaml
@@ -6,6 +6,7 @@ packages:
       - ca-certificates
       - ca-certificates-mozilla
       - cockpit-system
+      - cockpit-wicked
       - cockpit-ws
       - cockpit
       - conntrack-tools
@@ -23,8 +24,6 @@ packages:
       - libnss_usrfiles2
       - libpwquality-tools
       - microos-tools
-      - NetworkManager
-      - NetworkManager-branding-SLE
       - parted
       - pkgconfig
       - policycoreutils
@@ -40,6 +39,7 @@ packages:
       - transactional-update
       - transactional-update-zypp-config
       - vim-small
+      - wicked
       - yast2-logs
       - zypper-needs-restarting
   _namespace_yast2_schema:


### PR DESCRIPTION
Use wicked instead of NetworkManager in Micro 5.5 recipe as cloud-init and python-azure-agent have a depenency on wicked so installation cannot be avoided (bsc#1248284).