### PR TITLE
include grub2-x86_64-xen

### DIFF
--- a/data/platforms/csp/ec2/_sle15/packages.yaml
+++ b/data/platforms/csp/ec2/_sle15/packages.yaml
@@ -6,9 +6,6 @@ packages:
   _namespace_platforms_ec2_xen:
     package:
       - _attributes:
-          name: grub2-x86_64-xen
-          arch: x86_64
-      - _attributes:
           name: xen-libs
           arch: x86_64
   _namespace_platforms_ec2_xen_tools:

--- a/data/platforms/csp/ec2/packages.yaml
+++ b/data/platforms/csp/ec2/packages.yaml
@@ -5,6 +5,11 @@ packages:
       - cloud-init
       - cloud-init-config-suse
       - cloud-netconfig-ec2
+  _namespace_platforms_ec2_grub_xen:
+    package:
+      - _attributes:
+          name: grub2-x86_64-xen
+          arch: x86_64
   _namespace_platforms_ec2_registration:
     package:
       - cloud-regionsrv-client


### PR DESCRIPTION
Package grub2-x86_64-xen is required in all EC2 images.