### PR TITLE
Handle zypp configuration directory dynamically

### DIFF
--- a/data/base/pubcloud/_sle15/config.yaml
+++ b/data/base/pubcloud/_sle15/config.yaml
@@ -4,6 +4,9 @@ config:
       - path: /etc/pam.d/sshd
         append: True
         content: "session     optional    pam_motd.so"
+  scripts:
+    base_pubcloud_zypp_disable_delta_rpms:
+      - zypp-disable-delta-rpms
   sysconfig:
     base_pubcloud_sle15_sysvars:
       - file: /etc/sysconfig/console

--- a/data/base/pubcloud/config.yaml
+++ b/data/base/pubcloud/config.yaml
@@ -15,7 +15,6 @@ config:
       - remove-iscsi-config
       - remove-root-pw
       - set-prodlink
-      - zypp-disable-delta-rpms
       - zypp-disable-multiver-kernel
   services:
     base_pubcloud_services:

--- a/data/scripts/zypp-disable-multiver-kernel.sh
+++ b/data/scripts/zypp-disable-multiver-kernel.sh
@@ -1,1 +1,5 @@
-sed -i -e 's/latest,latest-1,running/latest,running/' /etc/zypp/zypp.conf
+if [ -f /etc/zypp/zypp.conf]; then
+    sed -i -e 's/latest,latest-1,running/latest,running/' /etc/zypp/zypp.conf
+else
+    echo "multiversion.kernels = latest" > /etc/zypp/zypp.conf.d/40_multiver_kernel_latest.conf
+fi

--- a/data/scripts/zypp-limit-concurrent-downloads.sh
+++ b/data/scripts/zypp-limit-concurrent-downloads.sh
@@ -1,2 +1,6 @@
 # limit number of concurrent connections to 1
-sed -i -e 's/^[# ]*download.max_concurrent_connections.*/download.max_concurrent_connections = 1/' /etc/zypp/zypp.conf
+if [ -f /etc/zypp/zypp.conf ]; then
+    sed -i -e 's/^[# ]*download.max_concurrent_connections.*/download.max_concurrent_connections = 1/' /etc/zypp/zypp.conf
+else
+    echo "download.max_concurrent_connections = 1" > /etc/zypp/zypp.conf.d/40_max_connections.conf
+fi


### PR DESCRIPTION
Zypper was converted to `/usr/etc` and configuration directories, this PR adjusts for that. Also drop setting `use_deltarpm` to false from SLFO based recipes (`false` is default from SLE 15 SP7).