### PR TITLE
Use new openldap2_6-client package in 16.x

### DIFF
--- a/data/base/pubcloud/_sle15/packages.yaml
+++ b/data/base/pubcloud/_sle15/packages.yaml
@@ -19,6 +19,7 @@ packages:
       - ksh
       - libyui-ncurses-pkg
       - nscd
+      - openldap2-client
       - tcpd
       - tcpdump
       - telnet

--- a/data/base/pubcloud/_slfo/packages.yaml
+++ b/data/base/pubcloud/_slfo/packages.yaml
@@ -3,11 +3,9 @@ packages:
     package:
       - btrfsprogs
       - btrfsmaintenance
+      - openldap2_6-client
       - tpm2.0-tools
       - system-user-tss
   _namespace_base_pubcloud_slfo_podman:
     package:
       - podman
-  _namespace_base_pubcloud_slfo_extra:
-    package:
-      - openldap2_6-client

--- a/data/base/pubcloud/_slfo/packages.yaml
+++ b/data/base/pubcloud/_slfo/packages.yaml
@@ -8,3 +8,6 @@ packages:
   _namespace_base_pubcloud_slfo_podman:
     package:
       - podman
+  _namespace_base_pubcloud_slfo_extra:
+    package:
+      - openldap2_6-client

--- a/data/base/pubcloud/packages.yaml
+++ b/data/base/pubcloud/packages.yaml
@@ -36,7 +36,6 @@ packages:
       - netcat-openbsd
       - nfs-client
       - nfs-kernel-server
-      - openldap2-client
       - polkit-default-privs
       - psmisc
       - quota


### PR DESCRIPTION
- SLE 15 keeps openldap2-client
- SLES 16.x will use the new packag openldap2_6-client instead