### PR TITLE
Do not include openldap client in SL Micro

### DIFF
--- a/data/base/pubcloud/_sl-micro/packages.yaml
+++ b/data/base/pubcloud/_sl-micro/packages.yaml
@@ -2,3 +2,4 @@ packages:
   _namespace_base_pubcloud_debug: Null
   _namespace_base_pubcloud_extra: Null
   _namespace_base_pubcloud_cockpit: Null
+  _namespace_base_pubcloud_openldap_client: Null

--- a/data/base/pubcloud/_sle15/packages.yaml
+++ b/data/base/pubcloud/_sle15/packages.yaml
@@ -19,7 +19,6 @@ packages:
       - ksh
       - libyui-ncurses-pkg
       - nscd
-      - openldap2-client
       - tcpd
       - tcpdump
       - telnet

--- a/data/base/pubcloud/_sles/ecs/packages.yaml
+++ b/data/base/pubcloud/_sles/ecs/packages.yaml
@@ -17,7 +17,6 @@ packages:
       - mozilla-nss-certs
       - nfs-client
       - nfs-kernel-server
-      - openldap2-client
       - patterns-base-minimal_base
       - polkit-default-privs
       - psmisc

--- a/data/base/pubcloud/_slfo/1.2/packages.yaml
+++ b/data/base/pubcloud/_slfo/1.2/packages.yaml
@@ -10,3 +10,6 @@ packages:
       - cockpit-storaged
       - cockpit-subscriptions
       - cockpit-ws
+  _namespace_base_pubcloud_openldap_client:
+    package:
+      - openldap2_6-client

--- a/data/base/pubcloud/_slfo/packages.yaml
+++ b/data/base/pubcloud/_slfo/packages.yaml
@@ -3,7 +3,6 @@ packages:
     package:
       - btrfsprogs
       - btrfsmaintenance
-      - openldap2_6-client
       - tpm2.0-tools
       - system-user-tss
   _namespace_base_pubcloud_slfo_podman:

--- a/data/base/pubcloud/packages.yaml
+++ b/data/base/pubcloud/packages.yaml
@@ -50,6 +50,9 @@ packages:
   _namespace_base_pubcloud_dhcp_client:
     package:
       - dhcp-client
+  _namespace_base_pubcloud_openldap_client:
+    package:
+      - openldap2-client
   _namespace_base_pubcloud_billing_flavor_check:
     package:
       - python-instance-billing-flavor-check


### PR DESCRIPTION
The last openldap2 client related change added `openldap2-client` to SL Micro 5.x recipes and `openldap2_6-client` to SL Micro 6.x and MLM 5.0 recipes where it is not wanted, and in the case of SL Micro 6.0 and MLM 5.0 resulted in unresolvables. This PR removes openldap from those recipes.