### PR TITLE
Drop python3-gcemetadata from SLE 15 recipes

### DIFF
--- a/data/platforms/csp/gce/_sle15/packages.yaml
+++ b/data/platforms/csp/gce/_sle15/packages.yaml
@@ -1,4 +1,0 @@
-packages:
-  _namespace_platforms_gce_metadata:
-    package:
-      - python3-gcemetadata


### PR DESCRIPTION
Package was replaced with python-gcemetadata.