### PR TITLE
Add script to drop non fips compliant kex algorithm

### DIFF
--- a/data/products/_sles/chost/16.0/config.yaml
+++ b/data/products/_sles/chost/16.0/config.yaml
@@ -1,3 +1,5 @@
 config:
   scripts:
     products_sles_selinux: Null
+    fips_kex:
+      - ssh-drop-non-fips-kex-algo

--- a/data/scripts/ssh-drop-non-fips-kex-algo.sh
+++ b/data/scripts/ssh-drop-non-fips-kex-algo.sh
@@ -1,0 +1,4 @@
+# Drop Key Exchange Algorithm that is not fips approved for ssh
+# bsc#1259495, bsc#1262555
+sed -i -e 's/mlkem768x25519-sha256,*//g; s/,,/,/g; s/,$//g'
+    /etc/crypto-policies/back-ends/opensshserver.config


### PR DESCRIPTION
CHOST images are set up to run in fips mode. The SLES ssh server configuration file includes the mlkem768x25519-sha256 key exchange algorithm, which is not fips certified. This leads to a start up failure of sshd in CHOST instances. Remove the offending kex algorithm from the config.