### PR TITLE
Drop obsolete sle-module-confidential-computing-release

### DIFF
--- a/data/base/pubcloud/_sle-hpc/payg/15-sp6/packages.yaml
+++ b/data/base/pubcloud/_sle-hpc/payg/15-sp6/packages.yaml
@@ -1,6 +1,0 @@
-packages:
-  _namespace_base_pubcloud_sle_hpc_module_cc:
-    package:
-      - _attributes:
-          name: sle-module-confidential-computing-release
-          arch: x86_64

--- a/data/base/pubcloud/_sles-sap/payg/15-sp6/packages.yaml
+++ b/data/base/pubcloud/_sles-sap/payg/15-sp6/packages.yaml
@@ -1,6 +1,0 @@
-packages:
-  _namespace_base_pubcloud_sles_sap_payg_module_confidential_computing:
-    package:
-      - _attributes:
-          name: sle-module-confidential-computing-release
-          arch: x86_64

--- a/data/base/pubcloud/_sles/ecs/15-sp6/packages.yaml
+++ b/data/base/pubcloud/_sles/ecs/15-sp6/packages.yaml
@@ -1,6 +1,0 @@
-packages:
-  _namespace_base_pubcloud_sles_payg_module_confidential_computing:
-    package:
-      - _attributes:
-          name: sle-module-confidential-computing-release
-          arch: x86_64

--- a/data/base/pubcloud/_sles/payg/15-sp6/packages.yaml
+++ b/data/base/pubcloud/_sles/payg/15-sp6/packages.yaml
@@ -1,6 +1,0 @@
-packages:
-  _namespace_base_pubcloud_sles_payg_module_confidential_computing:
-    package:
-      - _attributes:
-          name: sle-module-confidential-computing-release
-          arch: x86_64

--- a/data/base/pubcloud/_sles/sapcal/15-sp6/packages.yaml
+++ b/data/base/pubcloud/_sles/sapcal/15-sp6/packages.yaml
@@ -1,6 +1,0 @@
-packages:
-  _namespace_base_pubcloud_sapcal_module_confidential_computing:
-    package:
-      - _attributes:
-          name: sle-module-confidential-computing-release
-          arch: x86_64


### PR DESCRIPTION
Package sle-module-confidential-computing-release is not in any channel (anymore). There is a confidential compute SP7 channel defined but the release package is marked unsupported, and the only package in there is `snphost` (also marked unsupported).