### PR TITLE
Use config instead of setup section for ssh-drop-non-fips-kex-algo script

### DIFF
--- a/data/base/pubcloud/_sles/chost/16.0/config.yaml
+++ b/data/base/pubcloud/_sles/chost/16.0/config.yaml
@@ -1,4 +1,4 @@
-setup:
+config:
   scripts:
     base_pubcloud_chost_fips_kex:
       - ssh-drop-non-fips-kex-algo

--- a/images/pubcloud/sles-chost-byos/16.0/image.yaml
+++ b/images/pubcloud/sles-chost-byos/16.0/image.yaml
@@ -9,3 +9,4 @@ image:
     displayname: SLES-16.0-CHOST-BYOS
   description:
     specification: "SUSE Linux Enterprise Server 16.0 BYOS guest image optimized as container host"
+setup: Null


### PR DESCRIPTION
This was accidentally placed in `setup` and thus ends up in `images.sh`. Still works but it should really be in `config.sh`.