### PR TITLE
Include parted in all images

### DIFF
--- a/data/base/common/packages.yaml
+++ b/data/base/common/packages.yaml
@@ -16,6 +16,7 @@ packages:
       - ntp-daemon
       - pam
       - pam-config
+      - parted
       - procps
       - rpm
       - shadow

--- a/data/products/_sl-micro/5.3/packages.yaml
+++ b/data/products/_sl-micro/5.3/packages.yaml
@@ -23,7 +23,6 @@ packages:
       - less
       - libnss_usrfiles2
       - microos-tools
-      - parted
       - pkgconfig
       - policycoreutils
       - rebootmgr

--- a/data/products/_sl-micro/6.0/packages.yaml
+++ b/data/products/_sl-micro/6.0/packages.yaml
@@ -17,7 +17,6 @@ packages:
       - less
       - libcontainers-sles-mounts
       - NetworkManager-tui
-      - parted
       - podman
       - suse-build-key
       - suseconnect-ng


### PR DESCRIPTION
Add `parted` to common package selection so it is included in all images (currently missing from 16.x).