### PR TITLE
Enable cloud-init in SL Micro 6.x for Azure

### DIFF
--- a/data/platforms/csp/azure/_sl-micro/config.yaml
+++ b/data/platforms/csp/azure/_sl-micro/config.yaml
@@ -1,3 +1,0 @@
-config:
-  services:
-    platforms_azure_services: Null


### PR DESCRIPTION
cloud-init services were accidentally disabled in SL Micro 6.x for Azure.