### PR TITLE
Include dracut-kiwi-oem-repart

### DIFF
--- a/data/platforms/csp/azure-baremetal/overlayfiles.yaml
+++ b/data/platforms/csp/azure-baremetal/overlayfiles.yaml
@@ -3,6 +3,7 @@ archive:
     _include_overlays:
       - azure-baremetal-firewalld-conf
       - dracut-multipath
+      - dracut-kiwi-resize
       - modprobe-blacklist-azure-li
       - selinux-disable
       - sysctl-hana-basenet

--- a/data/platforms/csp/azure-baremetal/packages.yaml
+++ b/data/platforms/csp/azure-baremetal/packages.yaml
@@ -4,6 +4,7 @@ packages:
       - acl
       - azure-li-services
       - crash
+      - dracut-kiwi-oem-repart
       - gconf2
       - glibc-locale
       - grub2


### PR DESCRIPTION
Include dracut-kiwi-oem-repart in Azure LI/VLI recipes.