### PR TITLE
Do not remove cloud-netconfig from NETCONFIG_MODULES_ORDER

### DIFF
--- a/data/platforms/csp/azure/_sl-micro/5.3/config.yaml
+++ b/data/platforms/csp/azure/_sl-micro/5.3/config.yaml
@@ -3,5 +3,3 @@ config:
     platforms_azure_waagent: Null
   services:
     platforms_azure_services: Null
-  sysconfig:
-    platforms_azure_sle15_cloud_netconfig: Null


### PR DESCRIPTION
The last change accidentally removed cloud-netconfig from NETCONFIG_MODULES_ORDER sysconfig variable in Micro 5.x for Azure. Sorry about that. This PR restores it.