### PR TITLE
Fix issue with ECS agent and SELinux

### DIFF
--- a/data/base/pubcloud/_sles/ecs/15-sp4/config.yaml
+++ b/data/base/pubcloud/_sles/ecs/15-sp4/config.yaml
@@ -1,4 +1,6 @@
 config:
+  scripts:
+    base_pubcloud_sles_ecs_init_config: Null
   services:
     base_pubcloud_sles_ecs_services_sle15:
       - docker-img-store-setup

--- a/data/base/pubcloud/_sles/ecs/config.yaml
+++ b/data/base/pubcloud/_sles/ecs/config.yaml
@@ -2,6 +2,8 @@ config:
   scripts:
     base_pubcloud_sles_ecs_zypp_max_connections:
       - zypp-limit-concurrent-downloads
+    base_pubcloud_sles_ecs_init_config:
+      - ecs-init-config-pid-namespace
   services:
     base_pubcloud_sles_ecs_services:
       - amazon-ecs

--- a/data/scripts/ecs-init-config-pid-namespace.sh
+++ b/data/scripts/ecs-init-config-pid-namespace.sh
@@ -1,0 +1,2 @@
+# Required to make ECS agent work on systems in SELinux enforcing mode
+echo "ECS_AGENT_PID_NAMESPACE_HOST=true" > /etc/ecs/ecs.config


### PR DESCRIPTION
Set ECS_AGENT_PID_NAMESPACE_HOST=true in ECS init config, otherwise the agent fails to start in an enforcing SELinux system.