### PR TITLE
Enable SCAP hardening in CHOST 16.x

### DIFF
--- a/images/pubcloud/sles-chost-byos/16.0/image.yaml
+++ b/images/pubcloud/sles-chost-byos/16.0/image.yaml
@@ -9,4 +9,3 @@ image:
     displayname: SLES-16.0-CHOST-BYOS
   description:
     specification: "SUSE Linux Enterprise Server 16.0 BYOS guest image optimized as container host"
-setup: Null


### PR DESCRIPTION
The previous PR only added hardening to the CHOST 16.x recipe but the setup script was still disabled in the image definition. This PR enables it.