### PR TITLE
Fix include in SL Micro 5.5 image definition

### DIFF
--- a/images/pubcloud/sl-micro-byos/5.5/image.yaml
+++ b/images/pubcloud/sl-micro-byos/5.5/image.yaml
@@ -4,6 +4,9 @@ include-paths:
   - _sl-micro/5.3
   - _sl-micro/5.4
   - _sl-micro/5.5
+  - _sl-micro/byos/5.3
+  - _sl-micro/byos/5.4
+  - _sl-micro/byos/5.5
 image:
   _attributes:
     name: SLES15-SP5-Micro-5-5-BYOS


### PR DESCRIPTION
Fixes missing registration hint in motd (bsc#1268875).