### PR TITLE
Drop duplicate GCE package section

### DIFF
--- a/images/pubcloud/sles-chost-byos/content.yaml
+++ b/images/pubcloud/sles-chost-byos/content.yaml
@@ -38,7 +38,7 @@ image:
       packages:
         - _attributes:
             type: image
-            profiles: [Aliyun,GCE,OpenStack,GDC,SAP-CCloud]
+            profiles: [Aliyun,OpenStack,GDC,SAP-CCloud]
           _include:
             - base/pubcloud
           archive:


### PR DESCRIPTION
Drop GCE from the packages section of extra profiles. This is already covered by 'gce-base' and only results in duplicates.