### PR TITLE
Update CHOST hardening

### DIFF
--- a/data/base/pubcloud/_sles/chost/15-sp4/overlayfiles.yaml
+++ b/data/base/pubcloud/_sles/chost/15-sp4/overlayfiles.yaml
@@ -1,0 +1,2 @@
+archive:
+  _namespace_chost_hardened: Null

--- a/data/base/pubcloud/_sles/chost/15-sp6/config.yaml
+++ b/data/base/pubcloud/_sles/chost/15-sp6/config.yaml
@@ -21,9 +21,11 @@ setup:
           WantedBy=multi-user.target
   services:
     base_pubcloud_chost_hardening:
-      - aidecheck.service
+      - aidecheck
       - aidecheck.timer
   scripts:
+    base_pubcloud_chost_scripts_fips:
+      - enable-fips-mode
     base_pubcloud_chost_hardening:
       - pcs-hardening-workarounds
       - pcs-hardening-chost

--- a/data/base/pubcloud/_sles/chost/15-sp6/overlayfiles.yaml
+++ b/data/base/pubcloud/_sles/chost/15-sp6/overlayfiles.yaml
@@ -1,0 +1,4 @@
+archive:
+  _namespace_chost_hardened:
+    _include_overlays:
+      - pcs-hardening-sap

--- a/data/base/pubcloud/_sles/chost/15-sp6/packages.yaml
+++ b/data/base/pubcloud/_sles/chost/15-sp6/packages.yaml
@@ -6,3 +6,6 @@ packages:
       - openscap
       - openscap-utils
       - scap-security-guide
+  _namespace_base_pubcloud_chost_fips:
+    package:
+      - patterns-base-fips

--- a/data/base/pubcloud/_sles/chost/overlayfiles.yaml
+++ b/data/base/pubcloud/_sles/chost/overlayfiles.yaml
@@ -5,3 +5,6 @@ archive:
       - motd-mod-byos-opt
       - sysctl-enable-ip-forward
       - sysctl-enable-rp-filter
+  _namespace_chost_hardened:
+    _include_overlays:
+      - pcs-hardening-sap

--- a/data/platforms/csp/_sles/chost/15-sp6/preferences.yaml
+++ b/data/platforms/csp/_sles/chost/15-sp6/preferences.yaml
@@ -1,0 +1,5 @@
+preferences:
+  type:
+    _attributes:
+      kernelcmdline:
+        fips: 1

--- a/data/scripts/pcs-hardening-chost.sh
+++ b/data/scripts/pcs-hardening-chost.sh
@@ -1,6 +1,10 @@
+# rule use_pam_wheel_for_su expects pam_wheel to be in /etc/pam.d/su as comment
+grep -q pam_wheel /etc/pam.d/su || \
+    echo "auth      required    pam_wheel.so use_uid" >> /etc/pam.d/su
+
 # run image hardening script
 echo "run oscap --profile pcs-hardening-chost"
-oscap xccdf eval --remediate --profile pcs-hardening-chost /usr/share/xml/scap/ssg/content/ssg-sle15-ds.xml || {
+oscap xccdf eval --remediate --profile pcs-hardening-chost $ssg_file_build || {
     echo "!!!FAILED: --profile pcs-hardening-chost"
     /bin/false
 }

--- a/data/scripts/pcs-hardening-workarounds.sh
+++ b/data/scripts/pcs-hardening-workarounds.sh
@@ -6,24 +6,29 @@
 # Rule mount_option_dev_shm_noexec checks /proc/mounts which does not
 # make sense in build env.
 #
-# Disable smart card rules, does not make sense in the cloud.
-#
 # Disable any potential sysctl rules, they do not work properly in chroot.
+#
+# Temporarily disable broken sshd cipher/mac rules
+# (https://github.com/ComplianceAsCode/content/issues/14926)
 
 rules_to_disable="\
 xccdf_org.ssgproject.content_rule_mount_option_dev_shm_noexec
 xccdf_org.ssgproject.content_rule_aide_periodic_checking_systemd_timer
-xccdf_org.ssgproject.content_rule_install_smartcard_packages
-xccdf_org.ssgproject.content_rule_smartcard_configure_ca
-xccdf_org.ssgproject.content_rule_smartcard_configure_cert_checking
+xccdf_org.ssgproject.content_rule_service_kdump_disabled
+xccdf_org.ssgproject.content_rule_sshd_use_approved_ciphers
+xccdf_org.ssgproject.content_rule_sshd_use_approved_ciphers_ordered_stig
+xccdf_org.ssgproject.content_rule_sshd_use_approved_macs
+xccdf_org.ssgproject.content_rule_sshd_use_approved_macs_ordered_stig
 xccdf_org.ssgproject.content_rule_.*sysctl"
 
 ssg_file="/usr/share/xml/scap/ssg/content/ssg-sle15-ds.xml"
+ssg_file_build="/tmp/ssg-sle15-ds.xml"
 
 for rule in $rules_to_disable ; do
     echo "disable hardening rule $rule"
-    sed -i -e "/$rule/ s/selected=\"true\"/selected=\"false\"/" $ssg_file
+    sed_args="$sed_args -e '/$rule/ s/selected=\\\"true\\\"/selected=\\\"false\\\"/'"
 done
+eval sed $sed_args $ssg_file > $ssg_file_build
 
 # create empty /etc/security/opasswd file, otherwise mitigation for
 # xccdf_org.ssgproject.content_rule_file_etc_security_opasswd will fail

--- a/data/scripts/pcs-hardening.sh
+++ b/data/scripts/pcs-hardening.sh
@@ -1,6 +1,6 @@
 # run image hardening script
 echo "run oscap --profile pcs-hardening"
-oscap xccdf eval --remediate --profile pcs-hardening /usr/share/xml/scap/ssg/content/ssg-sle15-ds.xml || {
+oscap xccdf eval --remediate --profile pcs-hardening $ssg_file_build || {
     echo "!!!FAILED: --profile pcs-hardening"
     /bin/false
 }

--- a/data/scripts/pcs-sap-hardening.sh
+++ b/data/scripts/pcs-sap-hardening.sh
@@ -2,7 +2,7 @@
 ssg_file="/usr/share/xml/scap/ssg/content/ssg-sle15-ds.xml"
 
 echo "run oscap --profile pcs-hardening-sap"
-oscap xccdf eval --remediate --profile pcs-hardening-sap $ssg_file || {
+oscap xccdf eval --remediate --profile pcs-hardening-sap $ssg_file_build || {
     echo "!!!FAILED: --profile pcs-hardening-sap"
     /bin/false
 }


### PR DESCRIPTION
- Enable FIPS in CHOST 15 SP6+
- Include pcs-hardening-sap script (sysctl rules) in CHOST haredening
- Fix enabling aidecheck service
- Disable rules broken in buildenv only for build
- Add work-around for broken rule use_pam_wheel_for_su