### PR TITLE
Disable smartcard related hardening rules

### DIFF
--- a/data/scripts/pcs-hardening-workarounds.sh
+++ b/data/scripts/pcs-hardening-workarounds.sh
@@ -19,6 +19,7 @@ xccdf_org.ssgproject.content_rule_sshd_use_approved_ciphers
 xccdf_org.ssgproject.content_rule_sshd_use_approved_ciphers_ordered_stig
 xccdf_org.ssgproject.content_rule_sshd_use_approved_macs
 xccdf_org.ssgproject.content_rule_sshd_use_approved_macs_ordered_stig
+xccdf_org.ssgproject.content_rule_.*smartcard
 xccdf_org.ssgproject.content_rule_.*sysctl"
 
 ssg_file="/usr/share/xml/scap/ssg/content/ssg-sle15-ds.xml"


### PR DESCRIPTION
I jumped the gun a bit when updating the workarounds file. I removed disabling Smartcard related rules that were removed from the sle15 profile upstream, but it will take a while until this change made it into SLES.