### PR TITLE
Enable workload refresh timer

### DIFF
--- a/data/platforms/csp/gce/_sl-micro/5.5/config.yaml
+++ b/data/platforms/csp/gce/_sl-micro/5.5/config.yaml
@@ -7,3 +7,4 @@ config:
       - google-oslogin-cache.timer
       - google-shutdown-scripts
       - google-startup-scripts
+      - gce-workload-cert-refresh.timer

--- a/data/platforms/csp/gce/config.yaml
+++ b/data/platforms/csp/gce/config.yaml
@@ -24,6 +24,7 @@ config:
       - google-oslogin-cache.timer
       - google-shutdown-scripts
       - google-startup-scripts
+      - gce-workload-cert-refresh.timer
     platforms_gce_cloud_netconfig:
       - cloud-netconfig.timer
     platforms_gce_flexible_licenses_timer:


### PR DESCRIPTION
Enable the gce-workload-cert-refresh.timer from the google-guest-agent package. (bsc#1273192)