### PR TITLE
Fix CHOST FIPS mode setup

### DIFF
--- a/data/base/pubcloud/_sles/chost/15-sp6/config.yaml
+++ b/data/base/pubcloud/_sles/chost/15-sp6/config.yaml
@@ -1,4 +1,4 @@
-setup:
+config:
   files:
     base_pubcloud_chost_hardening:
       - path: /etc/systemd/system/aidecheck.service
@@ -26,6 +26,8 @@ setup:
   scripts:
     base_pubcloud_chost_scripts_fips:
       - enable-fips-mode
+setup:
+  scripts:
     base_pubcloud_chost_hardening:
       - pcs-hardening-workarounds
       - pcs-hardening-chost

--- a/data/base/pubcloud/_sles/chost/15-sp6/packages.yaml
+++ b/data/base/pubcloud/_sles/chost/15-sp6/packages.yaml
@@ -9,3 +9,4 @@ packages:
   _namespace_base_pubcloud_chost_fips:
     package:
       - patterns-base-fips
+      - crypto-policies-scripts

--- a/data/base/pubcloud/_sles/chost/packages.yaml
+++ b/data/base/pubcloud/_sles/chost/packages.yaml
@@ -30,3 +30,4 @@ packages:
   _namespace_base_pubcloud_chost_fips:
     package:
       - patterns-base-fips
+      - crypto-policies-scripts

--- a/data/scripts/enable-fips-mode.sh
+++ b/data/scripts/enable-fips-mode.sh
@@ -1,3 +1,1 @@
-cp /usr/share/crypto-policies/policies/FIPS.pol /etc/crypto-policies/state/CURRENT.pol
-echo FIPS > /etc/crypto-policies/state/current
-echo FIPS > /etc/crypto-policies/config
+update-crypto-policies --no-reload --set FIPS


### PR DESCRIPTION
Main change is the switch from fiddling with the crypto policies directly to using the `update-crypto-policies` script for enabling FIPS mode. Unlike the `fips-setup-mode` wrapper `update-crypto-policies` works fine in build environment.