### PR TITLE
Revert "Enable workload refresh timer"

### DIFF
--- a/data/platforms/csp/gce/_sl-micro/5.5/config.yaml
+++ b/data/platforms/csp/gce/_sl-micro/5.5/config.yaml
@@ -7,4 +7,3 @@ config:
       - google-oslogin-cache.timer
       - google-shutdown-scripts
       - google-startup-scripts
-      - gce-workload-cert-refresh.timer

--- a/data/platforms/csp/gce/config.yaml
+++ b/data/platforms/csp/gce/config.yaml
@@ -24,7 +24,6 @@ config:
       - google-oslogin-cache.timer
       - google-shutdown-scripts
       - google-startup-scripts
-      - gce-workload-cert-refresh.timer
     platforms_gce_cloud_netconfig:
       - cloud-netconfig.timer
     platforms_gce_flexible_licenses_timer:


### PR DESCRIPTION
This reverts commit 4a9845db17ed78ca97eda281c494d33d817823ba. The timer is not available yet for image building.