### PR TITLE
Use device persistency by label

### DIFF
--- a/data/platforms/csp/azure/_sle15/preferences.yaml
+++ b/data/platforms/csp/azure/_sle15/preferences.yaml
@@ -3,3 +3,5 @@ preferences:
     _attributes:
       bootpartition: "true"
       bootpartsize: 1024
+      kernelcmdline:
+        boot: LABEL=BOOT

--- a/data/platforms/csp/azure/preferences.yaml
+++ b/data/platforms/csp/azure/preferences.yaml
@@ -1,7 +1,6 @@
 preferences:
   type:
     _attributes:
-      devicepersistency: by-uuid
       efipartsize: 512
       format: vhd-fixed
       formatoptions: force_size
@@ -12,7 +11,6 @@ preferences:
         nvme_core.io_timeout: 240
         rootdelay: 300
         scsi_mod.use_blk_mq: 1
-        USE_BY_UUID_DEVICE_NAMES: 1
     bootloader:
       _attributes:
         console: serial


### PR DESCRIPTION
Set device persistency to by-label.
Drop obsolete parameter USE_BY_UUID_DEVICE_NAMES.
Set boot parameter to LABEL=BOOT (required by FIPS check).