### PR TITLE
Set /etc/machine-id to uninitialized

### DIFF
--- a/data/base/pubcloud/config.yaml
+++ b/data/base/pubcloud/config.yaml
@@ -14,6 +14,7 @@ config:
       - polkit-set-default-privs
       - remove-iscsi-config
       - remove-root-pw
+      - set-machine-id-uninitialized
       - set-prodlink
       - zypp-disable-multiver-kernel
   services:

--- a/data/scripts/set-machine-id-uninitialized.sh
+++ b/data/scripts/set-machine-id-uninitialized.sh
@@ -1,0 +1,1 @@
+echo "uninitialized" > /etc/machine-id


### PR DESCRIPTION
Set /etc/machine-id to uninitialized so first boot of instance is actually considered first boot by systemd.