### PR TITLE
Install sles-release instead of SLE_HPC-release

### DIFF
--- a/data/products/_sle-hpc/15-sp6/packages.yaml
+++ b/data/products/_sle-hpc/15-sp6/packages.yaml
@@ -1,0 +1,4 @@
+packages:
+  _namespace_product_sle_hpc_release:
+    package:
+      - sles-release


### PR DESCRIPTION
This reverts switch from `sles-release` to `SLE_HPC-release` by last commit. From 15 SP6, HPC is a SLES module rather than a separate product.

This also means we don't display anything HPC specific in `motd`. Should we add a caption like "Optimized for High-Performance Computing" like we do for other SLES variants (CHOST and ECS)? Links like https://documentation.suse.com/sle-hpc/15-SP7/ still work so we could use that in `motd` too.